### PR TITLE
Add sync-with-base-branch step to /ship to prevent merge conflicts

### DIFF
--- a/skills/ship.md
+++ b/skills/ship.md
@@ -59,7 +59,32 @@ If a linked issue number is identifiable, note it for the PR body. If not identi
 
 ---
 
-## Step 4 — Commit
+## Step 4 — Sync with base branch
+
+Bring the feature branch up to date before committing:
+
+{{#if BRANCH_DEV}}
+```
+git fetch origin {{BRANCH_DEV}} && git merge origin/{{BRANCH_DEV}}
+```
+{{/if}}
+{{#if !BRANCH_DEV}}
+```
+git fetch origin {{BRANCH_PROD}} && git merge origin/{{BRANCH_PROD}}
+```
+{{/if}}
+
+If the merge completes cleanly (including fast-forward), proceed to Step 5.
+
+If there are merge conflicts, **stop** and say:
+
+> "Merge conflicts with `<base branch>`. Resolve them before shipping."
+
+List the conflicting files. Help the user resolve them if asked, then continue.
+
+---
+
+## Step 5 — Commit
 
 Stage all changes and commit:
 ```
@@ -74,7 +99,7 @@ Commit message rules:
 
 ---
 
-## Step 5 — Push and open PR
+## Step 6 — Push and open PR
 
 First, push the branch:
 ```
@@ -121,9 +146,9 @@ Omit the issue line entirely if no linked issue was identified in Step 3.
 
 ---
 
-## Step 6 — Review (conditional)
+## Step 7 — Review (conditional)
 
-If `{{REVIEW_GATE}}` is `"off"`, skip directly to Step 7 (merge without review).
+If `{{REVIEW_GATE}}` is `"off"`, skip directly to Step 8 (merge without review).
 
 Otherwise, load `{{REVIEW_AGENT_PROMPT}}` and perform the review for this PR.
 
@@ -140,7 +165,7 @@ Wait for the review to complete and report its verdict.
 
 ---
 
-## Step 7 — Act on verdict
+## Step 8 — Act on verdict
 
 {{#if BRANCH_DEV}}
 Merge command (used by all paths below): `{{MERGE_CMD}}`


### PR DESCRIPTION
Adds a new Step 4 (Sync with base branch) to the /ship skill that runs `git fetch origin <base> && git merge origin/<base>` before committing. This ensures the feature branch is up to date with dev (or main in trunk mode) before any commit is made, preventing the merge conflicts that occur when sequential feature branches carry stale generated files.

Uses merge (not rebase) so it's safe for all cases: unpushed branches fast-forward, pushed branches get a clean merge commit without force push.

Issue #22