### PR TITLE
Fix deploy targets failing when local branch is behind remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,10 @@ endif
 
 # Push the integration branch for preview/testing.
 deploy-preview:
+	git pull --rebase origin $(INTEGRATION_BRANCH)
 	git push origin $(INTEGRATION_BRANCH)
 
 # Publish a tagged release to production.
 deploy-prod:
+	git pull --rebase origin $(PRODUCTION_BRANCH) --tags
 	git push origin $(PRODUCTION_BRANCH) --tags


### PR DESCRIPTION
Add `git pull --rebase` before `git push` in both `deploy-preview` and `deploy-prod` Makefile targets. This prevents non-fast-forward errors when the remote branch has commits (e.g., GitHub merge commits) not present locally.

Issue #27