### PR TITLE
Fix deploy targets failing when run from a non-target branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,10 +90,12 @@ endif
 
 # Push the integration branch for preview/testing.
 deploy-preview:
+	git checkout $(INTEGRATION_BRANCH)
 	git pull --rebase origin $(INTEGRATION_BRANCH)
 	git push origin $(INTEGRATION_BRANCH)
 
 # Publish a tagged release to production.
 deploy-prod:
+	git checkout $(PRODUCTION_BRANCH)
 	git pull --rebase origin $(PRODUCTION_BRANCH) --tags
 	git push origin $(PRODUCTION_BRANCH) --tags


### PR DESCRIPTION
Add `git checkout` to `deploy-preview` and `deploy-prod` so they switch to the target branch before pulling and pushing. Previously, running these targets from a different branch caused `git pull --rebase` to rebase the current branch instead of updating the target, leaving the local target ref stale and the push failing with a non-fast-forward error.

Issue #33