### PR TITLE
Fix deploy-prod tag clobber and add validate to make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ check:
 
 # Preview what sync would generate without writing any files.
 dev:
+	./sync.sh --validate
 	./sync.sh --dry-run
 
 # Regenerate .claude/commands/ and other adapter output from skills/.
@@ -97,5 +98,6 @@ deploy-preview:
 # Publish a tagged release to production.
 deploy-prod:
 	git checkout $(PRODUCTION_BRANCH)
-	git pull --rebase origin $(PRODUCTION_BRANCH) --tags
+	git pull --rebase origin $(PRODUCTION_BRANCH)
+	git fetch origin --tags --force
 	git push origin $(PRODUCTION_BRANCH) --tags


### PR DESCRIPTION
`make deploy-prod` was failing with "would clobber existing tag" rejections when local release tags diverged from the remote. Split the combined pull into a branch rebase plus a forced tag fetch so the remote remains authoritative for release tags.

Also wire `./sync.sh --validate` into `make dev` so placeholder validation runs alongside the dry-run preview as a preflight check.

Closes #89
