### PR TITLE
Validate permissions across all skill groups in CodeCannon's own CI

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -516,7 +516,14 @@ def main():
         else:
             print("Placeholder validation passed — all placeholders are defined.")
 
-        perm_errors = validate_permissions(all_skill_files)
+        # When sync.py runs from inside the CodeCannon repo itself (rather than
+        # as a consumer submodule), validate permissions across every skill group
+        # so a gap in a non-enabled group can't ship unnoticed.
+        if CODECANNON_DIR == project_root:
+            perm_skill_files = sorted(skills_dir.glob('*/*.md'))
+        else:
+            perm_skill_files = all_skill_files
+        perm_errors = validate_permissions(perm_skill_files)
         if perm_errors:
             print("\nPermission validation failed — commands not in permissions.yaml:\n")
             for e in perm_errors:

--- a/sync.py
+++ b/sync.py
@@ -402,7 +402,7 @@ def validate_permissions(skill_files):
                 # For simple commands (git, make), check the prefix
                 if token not in allowed and token not in seen:
                     seen.add(token)
-                    errors.append(f"  {skill_path.name}: command '{token}' not in permissions.yaml")
+                    errors.append(f"  {skill_path.parent.name}/{skill_path.name}: command '{token}' not in permissions.yaml")
 
     return errors
 


### PR DESCRIPTION
When `sync.py --validate` runs from inside the CodeCannon repo itself (detected via `CODECANNON_DIR == project_root`), the permissions check now walks every `skills/<group>/*.md` instead of just the enabled group's skills. Consumer projects (where CodeCannon is a submodule) continue to validate only their enabled group's skills, matching the runtime model.

This closes the gap where a skill added to a non-enabled group could ship with an un-listed shell command and pass CI / pre-commit locally — the issue would only surface when a downstream project enabled that group.

Placeholder validation remains scoped to the enabled group (placeholders are per-project; permissions are repo-global).

Closes #161
