### PR TITLE
Gate submit-for-review merge-target check on two-branch mode

### DIFF
--- a/skills/github-agile/submit-for-review.md
+++ b/skills/github-agile/submit-for-review.md
@@ -209,6 +209,7 @@ Wait for the review to complete and report its verdict.
 
 ## Step 8 — Act on verdict
 
+{{#if BRANCH_DEV}}
 Before merging, verify the merge target exists. Find the repo root with `git rev-parse --show-toplevel`, then extract the target name from `{{MERGE_CMD}}` (e.g. `make merge` → `merge`) and run:
 
 ```
@@ -221,7 +222,6 @@ If `make -n` exits non-zero, **stop** and say:
 
 Do not improvise a replacement command (e.g. do not fall back to `gh pr merge`). Do not proceed.
 
-{{#if BRANCH_DEV}}
 Merge command (used by all paths below): `{{MERGE_CMD}}`
 {{/if}}
 {{#if !BRANCH_DEV}}


### PR DESCRIPTION
Gates the Step 8 `MERGE_CMD` target-existence check in `submit-for-review` on two-/three-branch mode. Previously the `make -n <merge-target>` check ran unconditionally, before the branch-model split that selects the actual merge command. In trunk mode the merge command is `gh pr merge <n> --merge` and `MERGE_CMD` is never run — so any trunk project without a `merge` Makefile target hit a misleading hard-stop telling the user to add a target that would never be executed.

Moving the `{{#if BRANCH_DEV}}` guard up to enclose the whole check block makes it render only when the merge command is actually `MERGE_CMD`. Trunk mode now proceeds straight to `gh pr merge`. The Step 2 `CHECK_CMD` check is untouched (it runs in all modes). CodeCannon's own rendered output is byte-identical since it runs in dev mode.

Closes #190
