### PR TITLE
sync.py: apply schema-declared placeholder defaults generically

### DIFF
--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -193,20 +193,20 @@ placeholders:
     used_in: [start]
 
   QA_READY_LABEL:
-    description: "Label applied by /submit-for-review when a feature merges to BRANCH_DEV in two-branch mode, signaling it is ready for QA on the preview environment. In trunk and three-branch modes, /submit-for-review does not apply this label automatically. Only configure if you have an explicit QA gate for your integration branch environment."
-    default: "ready-for-qa"
+    description: "Label applied by /submit-for-review when a feature merges to BRANCH_DEV in two-branch mode, signaling it is ready for QA on the preview environment. In trunk and three-branch modes, /submit-for-review does not apply this label automatically. Only configure if you have an explicit QA gate for your integration branch environment. Empty (the default) disables the QA label workflow entirely — this is an opt-in feature, not merely an unset value, so its default must stay empty even though 'ready-for-qa' is the recommended label name once you do configure it."
+    default: ""
     category: github
     used_in: [submit-for-review, qa]
 
   QA_PASSED_LABEL:
-    description: "Label applied by /qa when a feature passes QA review. Leave empty to skip label application."
-    default: "qa-passed"
+    description: "Label applied by /qa when a feature passes QA review. Leave empty to skip label application. Empty (the default) is intentional — see QA_READY_LABEL."
+    default: ""
     category: github
     used_in: [qa]
 
   QA_FAILED_LABEL:
-    description: "Label applied by /qa when a feature fails QA review. Leave empty to skip label application."
-    default: "qa-failed"
+    description: "Label applied by /qa when a feature fails QA review. Leave empty to skip label application. Empty (the default) is intentional — see QA_READY_LABEL."
+    default: ""
     category: github
     used_in: [qa]
 

--- a/sync.py
+++ b/sync.py
@@ -139,6 +139,68 @@ def parse_yaml_simple(text):
     return result
 
 
+def load_schema_defaults(schema_path):
+    """Parse config.schema.yaml's `placeholders:` section into {NAME: default}.
+
+    Deliberately a dedicated parser rather than an extension of parse_yaml_simple:
+    the schema nests three levels deep (placeholders: -> NAME: -> default:), one
+    level deeper than parse_yaml_simple supports, and that parser is reused by
+    project .codecannon.yaml loading where the flatter shape is intentional.
+    Handles simple quoted values and literal block scalars (`default: |`).
+    """
+    defaults = {}
+    lines = schema_path.read_text().splitlines()
+    in_placeholders = False
+    current_key = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            i += 1
+            continue
+        indent = len(line) - len(line.lstrip())
+
+        if indent == 0:
+            in_placeholders = stripped.rstrip(':') == 'placeholders'
+            current_key = None
+            i += 1
+            continue
+
+        if not in_placeholders:
+            i += 1
+            continue
+
+        if indent == 2 and stripped.endswith(':'):
+            current_key = stripped[:-1]
+            i += 1
+            continue
+
+        if indent == 4 and stripped.startswith('default:') and current_key:
+            value = stripped[len('default:'):].strip()
+            if value in ('|', '|-', '|+'):
+                block_lines = []
+                i += 1
+                while i < len(lines) and (not lines[i].strip() or (len(lines[i]) - len(lines[i].lstrip())) > 4):
+                    block_lines.append(lines[i])
+                    i += 1
+                content_indent = min(
+                    (len(l) - len(l.lstrip()) for l in block_lines if l.strip()), default=0)
+                block_value = '\n'.join(
+                    l[content_indent:] if l.strip() else '' for l in block_lines).rstrip('\n')
+                if block_value and value != '|-':
+                    block_value += '\n'
+                defaults[current_key] = block_value
+                continue
+            defaults[current_key] = _dequote(value)
+            i += 1
+            continue
+
+        i += 1
+
+    return defaults
+
+
 def parse_frontmatter(text):
     """Extract YAML frontmatter between --- delimiters. Returns (fm_dict, body_str)."""
     match = re.match(r'^---\n(.*?)\n---\n(.*)', text, re.DOTALL)
@@ -628,9 +690,14 @@ def main():
     project_config = raw_config.get('config', {})
     skill_group = raw_config.get('skill_group', '')
 
-    # Default for optional placeholders that the template ships commented out
-    # but skills reference unconditionally. Matches the documented default.
-    project_config.setdefault('TICKET_LABEL_CREATION_ALLOWED', 'false')
+    # Apply schema-declared defaults for any placeholder the project config
+    # omits (e.g. optional settings the template ships commented out but
+    # skills reference unconditionally). config.schema.yaml is the single
+    # source of truth for these — never hardcode a default here.
+    schema_path = CODECANNON_DIR / 'config.schema.yaml'
+    if schema_path.exists():
+        for key, default_value in load_schema_defaults(schema_path).items():
+            project_config.setdefault(key, default_value)
 
     if not adapters_list:
         print("Error: no adapters specified in config. Add 'adapters: [claude]' to .codecannon.yaml")

--- a/sync.py
+++ b/sync.py
@@ -139,6 +139,23 @@ def parse_yaml_simple(text):
     return result
 
 
+def _strip_inline_comment(s):
+    """Strip a trailing ` #...` comment from a single-line YAML scalar, honoring quotes.
+
+    Only a `#` outside any quoted span, preceded by whitespace or at position 0,
+    starts a comment — matches the convention used elsewhere for full-line comments.
+    """
+    in_squote = in_dquote = False
+    for idx, ch in enumerate(s):
+        if ch == '"' and not in_squote:
+            in_dquote = not in_dquote
+        elif ch == "'" and not in_dquote:
+            in_squote = not in_squote
+        elif ch == '#' and not in_squote and not in_dquote and (idx == 0 or s[idx - 1].isspace()):
+            return s[:idx].rstrip()
+    return s
+
+
 def load_schema_defaults(schema_path):
     """Parse config.schema.yaml's `placeholders:` section into {NAME: default}.
 
@@ -171,13 +188,16 @@ def load_schema_defaults(schema_path):
             i += 1
             continue
 
-        if indent == 2 and stripped.endswith(':'):
-            current_key = stripped[:-1]
-            i += 1
-            continue
+        if indent == 2 and ':' in stripped:
+            key_part, _, rest = stripped.partition(':')
+            rest = rest.strip()
+            if rest == '' or rest.startswith('#'):
+                current_key = key_part.strip()
+                i += 1
+                continue
 
         if indent == 4 and stripped.startswith('default:') and current_key:
-            value = stripped[len('default:'):].strip()
+            value = _strip_inline_comment(stripped[len('default:'):].strip())
             if value in ('|', '|-', '|+'):
                 block_lines = []
                 i += 1
@@ -199,6 +219,18 @@ def load_schema_defaults(schema_path):
         i += 1
 
     return defaults
+
+
+def apply_schema_defaults(project_config, schema_path):
+    """Backfill project_config with config.schema.yaml's declared defaults, in place.
+
+    Used by both main() and the golden-file snapshot test so the two never diverge
+    on what "the real sync behavior" applies. No-op if schema_path doesn't exist.
+    """
+    if not schema_path.exists():
+        return
+    for key, default_value in load_schema_defaults(schema_path).items():
+        project_config.setdefault(key, default_value)
 
 
 def parse_frontmatter(text):
@@ -694,10 +726,7 @@ def main():
     # omits (e.g. optional settings the template ships commented out but
     # skills reference unconditionally). config.schema.yaml is the single
     # source of truth for these — never hardcode a default here.
-    schema_path = CODECANNON_DIR / 'config.schema.yaml'
-    if schema_path.exists():
-        for key, default_value in load_schema_defaults(schema_path).items():
-            project_config.setdefault(key, default_value)
+    apply_schema_defaults(project_config, CODECANNON_DIR / 'config.schema.yaml')
 
     if not adapters_list:
         print("Error: no adapters specified in config. Add 'adapters: [claude]' to .codecannon.yaml")

--- a/templates/codecannon.yaml
+++ b/templates/codecannon.yaml
@@ -119,6 +119,11 @@ config:
   # Leave empty to skip label application on fail.
   # QA_FAILED_LABEL: "qa-failed"
 
+  # ── Status skill ───────────────────────────────────────────────────────────
+  # Days after which an open PR or issue is flagged stale in /status output.
+  # Set to 0 to disable stale detection entirely.
+  # STALE_DAYS: "14"
+
   # ── Review agent conventions ──────────────────────────────────────────────────
   # These values are injected into the review agent prompt at sync time.
   # Use YAML block scalars (|) for multi-line content. HTML comments are invisible

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -217,10 +217,57 @@ class TestLoadSchemaDefaults(unittest.TestCase):
         self.assertEqual(result["MULTI_LINE"], "- one\n- two\n")
         self.assertNotIn("skill_group", result)
 
+    def test_default_with_inline_comment(self):
+        """A trailing ` # comment` after a quoted default must not corrupt the value.
+        Regression test: previously `default: "main"  # note` parsed to the literal
+        string with quotes and comment still attached, since the comment was never
+        stripped before _dequote() (which only strips quotes at the exact string ends).
+        """
+        schema_text = (
+            "placeholders:\n"
+            "\n"
+            "  BRANCH_PROD:\n"
+            "    default: \"main\"  # matches templates/codecannon.yaml\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            schema_path = Path(tmpdir) / "config.schema.yaml"
+            schema_path.write_text(schema_text)
+            result = sync.load_schema_defaults(schema_path)
+        self.assertEqual(result["BRANCH_PROD"], "main")
+
+    def test_key_line_with_inline_comment(self):
+        """A trailing ` # comment` on a placeholder key line must not hide the key.
+        Regression test: previously `FOO:  # note` failed the strict `endswith(':')`
+        check, so current_key was never set and the following default: line — guarded
+        on `current_key` — was silently skipped, dropping the default entirely.
+        """
+        schema_text = (
+            "placeholders:\n"
+            "\n"
+            "  FOO:  # a note\n"
+            "    default: \"bar\"\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            schema_path = Path(tmpdir) / "config.schema.yaml"
+            schema_path.write_text(schema_text)
+            result = sync.load_schema_defaults(schema_path)
+        self.assertEqual(result.get("FOO"), "bar")
+
     def test_real_schema_defines_stale_days(self):
         """Regression test for #194: STALE_DAYS must have a schema default."""
         result = sync.load_schema_defaults(REPO_ROOT / "config.schema.yaml")
         self.assertEqual(result.get("STALE_DAYS"), "14")
+
+    def test_qa_labels_default_empty_to_preserve_opt_out(self):
+        """QA_READY_LABEL/QA_PASSED_LABEL/QA_FAILED_LABEL must default to "" — they
+        gate {{#if}} sections in qa.md / submit-for-review.md that templates/codecannon.yaml
+        documents as "leave empty to disable". A non-empty schema default would flip
+        those sections on for every project that never configured QA labeling.
+        """
+        result = sync.load_schema_defaults(REPO_ROOT / "config.schema.yaml")
+        self.assertEqual(result.get("QA_READY_LABEL"), "")
+        self.assertEqual(result.get("QA_PASSED_LABEL"), "")
+        self.assertEqual(result.get("QA_FAILED_LABEL"), "")
 
     def test_real_schema_all_placeholders_have_defaults(self):
         """Every entry under placeholders: in the real schema should parse a default."""
@@ -1025,11 +1072,8 @@ class TestGoldenFileSnapshots(unittest.TestCase):
         raw_config = sync.parse_yaml_simple(config_path.read_text())
         adapters_list = raw_config.get("adapters", [])
         project_config = raw_config.get("config", {})
-        # Mirrors main()'s schema-default application, not a hardcoded special case.
-        schema_path = REPO_ROOT / "config.schema.yaml"
-        if schema_path.exists():
-            for key, default_value in sync.load_schema_defaults(schema_path).items():
-                project_config.setdefault(key, default_value)
+        # Same helper main() uses, so this test can't silently drift from real behavior.
+        sync.apply_schema_defaults(project_config, REPO_ROOT / "config.schema.yaml")
         skill_group = raw_config.get("skill_group", "")
         if not skill_group:
             self.skipTest("skill_group not set in .codecannon.yaml")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -173,6 +174,65 @@ class TestParseYamlSimple(unittest.TestCase):
         text = "config:\n  NOTES: |\n    last line"
         result = sync.parse_yaml_simple(text)
         self.assertEqual(result["config"]["NOTES"], "last line\n")
+
+
+class TestLoadSchemaDefaults(unittest.TestCase):
+    """Tests for load_schema_defaults(), which reads placeholder defaults
+    out of config.schema.yaml so main() never has to hardcode them.
+    """
+
+    def test_simple_and_block_scalar_defaults(self):
+        schema_text = (
+            "top_level:\n"
+            "\n"
+            "  skill_group:\n"
+            "    description: not a placeholder default\n"
+            "    default: should-not-appear\n"
+            "\n"
+            "placeholders:\n"
+            "\n"
+            "  BRANCH_PROD:\n"
+            "    description: prod branch\n"
+            "    default: \"main\"\n"
+            "    category: branches\n"
+            "\n"
+            "  EMPTY_DEFAULT:\n"
+            "    description: intentionally blank\n"
+            "    default: \"\"\n"
+            "\n"
+            "  MULTI_LINE:\n"
+            "    description: a list\n"
+            "    default: |\n"
+            "      - one\n"
+            "      - two\n"
+            "    category: review\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            schema_path = Path(tmpdir) / "config.schema.yaml"
+            schema_path.write_text(schema_text)
+            result = sync.load_schema_defaults(schema_path)
+
+        self.assertEqual(result["BRANCH_PROD"], "main")
+        self.assertEqual(result["EMPTY_DEFAULT"], "")
+        self.assertEqual(result["MULTI_LINE"], "- one\n- two\n")
+        self.assertNotIn("skill_group", result)
+
+    def test_real_schema_defines_stale_days(self):
+        """Regression test for #194: STALE_DAYS must have a schema default."""
+        result = sync.load_schema_defaults(REPO_ROOT / "config.schema.yaml")
+        self.assertEqual(result.get("STALE_DAYS"), "14")
+
+    def test_real_schema_all_placeholders_have_defaults(self):
+        """Every entry under placeholders: in the real schema should parse a default."""
+        result = sync.load_schema_defaults(REPO_ROOT / "config.schema.yaml")
+        schema_text = (REPO_ROOT / "config.schema.yaml").read_text()
+        # Only count keys under `placeholders:` (after the top_level: block ends)
+        placeholders_start = schema_text.index("placeholders:")
+        placeholder_names = re.findall(
+            r"^  ([A-Z_]+):$", schema_text[placeholders_start:], re.MULTILINE)
+        self.assertTrue(placeholder_names, "fixture sanity check: schema should list placeholders")
+        for name in placeholder_names:
+            self.assertIn(name, result, f"{name} has no parsed default")
 
 
 class TestParseFrontmatter(unittest.TestCase):
@@ -909,6 +969,22 @@ class TestMainCLI(unittest.TestCase):
                     sync.main()
                 self.assertEqual(ctx.exception.code, 1)
 
+    def test_validate_passes_when_optional_placeholder_omitted(self):
+        """A project config that omits an optional, schema-defaulted placeholder
+        (STALE_DAYS) should still validate — main() must backfill it from
+        config.schema.yaml rather than requiring it to be spelled out.
+        Regression test for #194.
+        """
+        self._chdir_to_project()
+        real_config = (REPO_ROOT / ".codecannon.yaml").read_text()
+        lines = [l for l in real_config.splitlines() if "STALE_DAYS" not in l]
+        self.assertNotIn("STALE_DAYS", "\n".join(lines), "fixture setup: STALE_DAYS should be stripped")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cfg = Path(tmpdir) / "no-stale-days.yaml"
+            cfg.write_text("\n".join(lines) + "\n")
+            with patch("sys.argv", ["sync.py", "--config", str(cfg), "--validate"]):
+                sync.main()  # should not raise SystemExit(1)
+
     def test_nonexistent_skill_group_exits_1(self):
         """skill_group naming a directory that doesn't exist should fail loudly."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -949,7 +1025,11 @@ class TestGoldenFileSnapshots(unittest.TestCase):
         raw_config = sync.parse_yaml_simple(config_path.read_text())
         adapters_list = raw_config.get("adapters", [])
         project_config = raw_config.get("config", {})
-        project_config.setdefault("TICKET_LABEL_CREATION_ALLOWED", "false")
+        # Mirrors main()'s schema-default application, not a hardcoded special case.
+        schema_path = REPO_ROOT / "config.schema.yaml"
+        if schema_path.exists():
+            for key, default_value in sync.load_schema_defaults(schema_path).items():
+                project_config.setdefault(key, default_value)
         skill_group = raw_config.get("skill_group", "")
         if not skill_group:
             self.skipTest("skill_group not set in .codecannon.yaml")


### PR DESCRIPTION
`config.schema.yaml` documents a `default` for every placeholder, but `sync.py` never actually read that file — the only default ever applied was a single hardcoded special case (`TICKET_LABEL_CREATION_ALLOWED`). Any other schema-declared default, like `STALE_DAYS`, silently went unenforced: a project without it explicit in `.codecannon.yaml` got an "unresolved placeholders" warning and a literal `{{STALE_DAYS}}` token in the generated `/status` skill.

## Changes

- Added `load_schema_defaults()` to `sync.py` — a dedicated parser for the `placeholders:` section of `config.schema.yaml` (it nests one level deeper than `parse_yaml_simple` supports, so this is a separate, purpose-built parser rather than an extension of the general one). Handles both simple quoted defaults and the one block-scalar default (`SENSITIVE_AREAS_CATEGORIES`), and now handles inline `#` comments on both key lines and default-value lines without corrupting or dropping the entry.
- Added `apply_schema_defaults(project_config, schema_path)` — a shared helper `main()` and the golden-file snapshot test both call, so they can't silently diverge on what "the real sync behavior" is.
- `main()` now backfills every placeholder's schema default via `setdefault`, replacing the hardcoded `TICKET_LABEL_CREATION_ALLOWED` special case entirely — schema and behavior can no longer drift.
- Documented `STALE_DAYS` in `templates/codecannon.yaml` (commented-out example) for consistency with every other placeholder.
- **Fixed `QA_READY_LABEL` / `QA_PASSED_LABEL` / `QA_FAILED_LABEL` defaults to `""`** (previously "ready-for-qa" / "qa-passed" / "qa-failed") — `templates/codecannon.yaml` documents these as "leave empty to disable the QA label workflow," so a non-empty schema default would have silently flipped the QA label workflow on for every existing project on its next sync, contradicting that documented opt-out. This was caught in review; see below.
- Added regression tests: `load_schema_defaults()` parsing (simple + block scalar + inline-comment defaults), a real-schema check that every placeholder parses a default, an explicit check that the QA label defaults stay empty, and an end-to-end `--validate` test against a config with `STALE_DAYS` stripped (reproduces the original bug, confirmed failing on unpatched code).

## Heads up for existing projects

`SENSITIVE_AREAS_GATE` (schema default `"true"`) and `PLATFORM_COMPLIANCE_NOTES` / `CONVENTIONS_NOTES` (schema defaults are non-empty placeholder comments) were also never actually enforced before this fix, despite being documented in the schema. This PR makes them take effect for the first time: any existing project that never explicitly set `SENSITIVE_AREAS_GATE` will get the sensitive-area CRITICAL-finding gate turned on in its generated `review-agent.md` on its next sync — this matches the schema's stated intent, but is a real, visible change in generated review-agent behavior worth knowing about if you maintain a downstream `.codecannon.yaml`.

## Test plan

- `python3 -m unittest discover -s tests` — 116 tests pass.
- `./sync.py --validate && ./sync.py --dry-run` — passes clean, no drift in this repo's own generated output.
- Manually reproduced the original bug (stripped `STALE_DAYS` from a copy of `.codecannon.yaml`, confirmed `--validate` failed on pre-fix code via `git stash`, passed after).
- Manually confirmed `QA_READY_LABEL`/`QA_PASSED_LABEL`/`QA_FAILED_LABEL` parse to `""` from the real schema, preserving today's opt-out behavior for projects that never configure QA labeling.
- Full review pass (8 finder angles + adversarial verify) posted to this PR; the one CRITICAL finding (QA label defaults) is fixed above.

Closes #194
