### PR TITLE
Pull back procedural over-specification in skills; document the skill-design philosophy

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -9,25 +9,24 @@ description: Code Cannon: Bump the project version, create a GitHub Release, and
 
 ## What `/deploy` does
 
-`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote to production).
+`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote the deploy branch to production first).
+
+The branching mode changes the shape of the release: in **trunk mode** (`BRANCH_PROD` only) `/deploy` tags and releases the current branch directly; in **multi-branch mode** (`BRANCH_DEV` set, optionally with `BRANCH_TEST`) it first opens and merges a release PR from the deploy branch into production, and that merge is what closes the linked issues.
 
 ---
 
-## Step 1 — Verify branch
+## Step 1 — Verify branch and sync
 
-Run:
-```bash
-git branch --show-current
-```
+Run `git branch --show-current`. The **deploy branch** for this project is:
 
-Required branch: `dev` (two-branch mode).
+`dev` (two-branch mode).
 
-If not on the required branch, abort and say: "Switch to `<required-branch>` before running `/deploy`."
+If not on the deploy branch, abort: "Switch to `<deploy-branch>` before running `/deploy`."
 
-Sync to the remote before proceeding. The script below guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<base>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from CodeCannon's own merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they get silently discarded.
+Then sync it to the remote. The script guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<deploy-branch>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they are silently discarded.
 
 ```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py dev
+python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py <deploy-branch>
 ```
 
 If the script exits non-zero, stop and resolve the issue it reports before continuing.
@@ -36,87 +35,35 @@ If the script exits non-zero, stop and resolve the issue it reports before conti
 
 ## Step 2 — Check current state
 
-### Find the latest version tag
+Find the latest version tag (`git describe --tags --abbrev=0`; if none, note this is the first release) and read the current version with `cat VERSION`.
+
+Show the merge commits (and their PRs) since the last tag. The range depends on the mode:
 
 ```bash
-git describe --tags --abbrev=0
+git log main..<deploy-branch> --merges --pretty=format:"%s"
 ```
 
-If no tag exists, note this is the first release.
+Merge-commit subjects have the form `Merge pull request #N from branch/name` — parse the PR numbers, then retrieve each body with `gh pr view <N> --json number,title,body`.
 
-### Read current version
+From those PR bodies, compile the release's issue links:
 
-```bash
-cat VERSION
-```
+Keep closing keywords and context references **separate — do not merge them into one set**:
 
-### Show commits since last tag
+- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines so they can be reproduced verbatim in the release PR body.
+- **Reference set** — issues mentioned only via `Related to #N` or the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the human gate surfaces it so you can manually close any straggler that should have closed.
+- **PRs included** (number + title).
 
-If a previous tag exists, show what's on the branch since that tag:
+Also check for open unmerged PRs (`gh pr list --state open --json number,title,headRefName`).
 
-```bash
-git log main..dev --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
-
-Extract closing keywords **separately** from context references — do **not** merge them into a single set:
-
-- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These issues will auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines it contained so they can be reproduced verbatim in the release PR body.
-- **Reference set** — issues mentioned only via `Related to #N`, or via the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the HUMAN GATE surfaces it so you can manually close any straggler that should have been a `Closes`.
-
-Compile:
-- List of PRs included (number + title)
-- Close set and reference set, kept distinct
-
-### Check for open unmerged PRs
-
-```bash
-gh pr list --state open --json number,title,headRefName
-```
-
-### Present the summary
-
-Tell the user:
-
-```
-Current version: X.Y.Z
-Latest tag: vX.Y.Z
-
-Commits/PRs since last tag:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
-
-Open PRs not yet merged:
-  #19 — Add dark mode (feature/dark-mode)
-
-Would you like to bump the version before deploying?
-  - **patch** → X.Y.C
-  - **minor** → X.B.0
-  - **major** → A.0.0
-  - **specific** → enter a version number
-  - **skip** → proceed to release with the latest existing tag
-```
-
-Wait for their response.
+Present a summary — current version, latest tag, the PRs/issues since that tag, any open PRs — and ask whether to bump the version before deploying (patch → X.Y.C, minor → X.B.0, major → A.0.0, a specific version, or skip to release the latest existing tag). Wait for their response.
 
 ---
 
 ## Step 3 — Version bump (if requested)
 
-If the user chose to skip, find the latest version tag in the branch history:
-```bash
-git describe --tags --abbrev=0
-```
+If the user chose **skip**, use the latest existing tag (`git describe --tags --abbrev=0`) as the release version. If none exists (first release), warn "No version tag found. You must bump the version before deploying." and return to the bump prompt.
 
-If no tag is found at all (first release), warn: "No version tag found. You must bump the version before deploying." Return to the version bump prompt. Otherwise, use the tag found as the release version.
-
-If the user chose a bump level, map their response to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it for the release step.
+If the user chose a bump level, map it to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it as `<new-version>`.
 
 | User says | `--bump-cmd` |
 |---|---|
@@ -131,59 +78,37 @@ python3 CodeCannon/skills/github-agile/scripts/bump-and-tag.py \
   --version-read-cmd "cat VERSION"
 ```
 
-If the script exits non-zero, stop and resolve the issue it reports before continuing. On success, the version printed on stdout is the new version — use it as `<new-version>` in subsequent steps.
+If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
 ---
 
 ## Step 4 — Compute release contents
 
-Determine the version tag (either from the bump just performed, or from the existing HEAD tag if the user skipped bumping).
+Determine the release version tag (from the bump just performed, or the existing HEAD tag if the user skipped). Find the previous tag for the changelog range: `git describe --abbrev=0 <version-tag>^`.
 
-Find the previous tag to determine the range:
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
+Reuse the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch as needed.
 
 ---
 
 ## Step 5 — HUMAN GATE
 
-Show the user the release summary. Example format:
+Show the release summary — the target version, the PRs included, and the issue links:
 
-```
-Ready to release vX.Y.Z to production.
+- Issues that will **close** on merge (the close set, reproduced verbatim from constituent PRs).
+- Issues **referenced but not closing** (the reference set — confirm none of these should actually close).
 
-PRs included:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
+Confirm the deploy branch has been tested:
+"Have you tested all of the above on preview? Type 'release' to confirm."
 
-Issues that will close on merge (Closes #N, reproduced verbatim from constituent PRs):
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
-
-Issues referenced but NOT closing (Related to #N / legacy Issue #N — confirm none of these should actually close):
-  #20 — Tighten error copy on the upload form
-
-Have you tested all of the above on preview? Type 'release' to confirm.
-```
-
-Wait for the user to type "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
+Wait for "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
 
 ---
 
-## Step 6 — Create PR: `dev` → `main`
+## Step 6 — Promote: `<deploy-branch>` → `main`
 
-First, create a temp directory for this invocation:
+Create a temp directory for this invocation (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`) and note the returned path — use it for all temp files here.
 
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
+Use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
 
 ```markdown
 Release vX.Y.Z
@@ -198,53 +123,31 @@ Closes #15
 Related to #20
 ```
 
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
+Reproduce **every** `Closes #N` line from the close set — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear without triggering an auto-close; if the reference set is empty, omit the `Related to` lines entirely.
 
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
+Create the PR (do NOT use `--body`, `--body-file -`, or heredocs), with `--head` set to the deploy branch:
 
 ```bash
-gh pr create --base main --head dev \
+gh pr create --base main --head <deploy-branch> \
   --title "Release vX.Y.Z" \
   --body-file <tmpdir>/release_pr_body.md
 ```
 
-Note the PR number from the output.
+> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close. The `Closes #N` lines auto-close the linked issues because this PR merges into `main` (the default branch).
 
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `main` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
+Then merge. Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge <pr-number> --merge` directly.
 
 ---
 
-## Step 7 — Merge
+## Step 7 — Create the GitHub Release
 
-Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
+**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action; the confirmation from Step 5 authorized the promotion, but the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
 
 > Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
 
 Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
 
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
+The version tag and PR/issue list are already known; the previous tag comes from Step 4 (if there is no previous tag, omit the "Full changelog" line). Create a temp directory if you haven't already (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`), then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
 
 ```markdown
 ## Changes
@@ -255,7 +158,7 @@ Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (sam
 **Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
 ```
 
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
+Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`; if a PR had no linked issue, use just the PR title. Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
 
 ```bash
 gh release create <version-tag> \
@@ -263,15 +166,11 @@ gh release create <version-tag> \
   --notes-file <tmpdir>/release_notes.md
 ```
 
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
+Note the release URL from the output.
 
 ---
 
-## Step 9 — Report
+## Step 8 — Report
 
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
-<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: codex | hash: 16a3f904 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+Tell the user: "Released vX.Y.Z. Linked issues are closed. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
+<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: codex | hash: 10153e09 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.agents/skills/start/SKILL.md
+++ b/.agents/skills/start/SKILL.md
@@ -27,12 +27,10 @@ Otherwise → go to **Case A: New work**.
 
 > **Execution order:** Resolve labels and milestones **now**, before entering Case A Step 1. If milestone auto-detection requires a user prompt (2+ open milestones), that prompt happens here — not later during issue creation. By the time you reach Step 2's human gate, all metadata must already be resolved so that Step 3 can proceed without re-prompting.
 
-The argument string may contain optional inline flags after the description. Parse as follows:
+The description may be followed by optional flags — `--label`/`-l` and `--milestone`/`-m`, in any order. Separate the description from the flags yourself; the flags carry these meanings:
 
-1. **Identify flags** — scan for the first token that starts with `--label`, `-l`, `--milestone`, or `-m`. Everything before it is the **description**. Everything from the first flag onward is **flags**.
-2. **`--label <value>` / `-l <value>`** — comma-separated label string (e.g. `bug` or `enhancement,ux`). If provided, it **bypasses label auto-selection entirely** for this invocation — use the value verbatim. Labels containing spaces must be quoted (e.g. `--label "good first issue"`).
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). Pass the value as-is; GitHub accepts both names and numbers.
-4. **Flags may appear in any order** after the description.
+- **`--label <value>` / `-l <value>`** — a comma-separated label string used **verbatim**, bypassing label auto-selection entirely for this invocation. Quote values containing spaces (e.g. `--label "good first issue"`).
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number (GitHub accepts both names and numbers).
 
 **Label resolution (three-tier, Case A only):**
 
@@ -56,14 +54,6 @@ After parsing flags, determine the active milestone in this order:
    - **0 results** → no milestone; proceed without `--milestone`.
    - **1 result** → use its title silently. Inform the user inline: `(milestone: <title>)`.
    - **2+ results** → show the numbered list, ask once: **"Multiple open milestones — which should this issue go under? (enter a number or title, or 'none')"**. Accept milestone number, title, or "none"/"skip". Wait for response before continuing.
-
-**Examples:**
-
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
 
 > Replace vs append: flags **replace** auto-selection entirely, they do not append. This avoids silent label duplication and milestone conflicts.
 
@@ -102,7 +92,7 @@ If on any other branch → proceed to Case A or Case B as determined by the `$AR
 
 ### Step 1 — Investigate
 
-Read the relevant code. Propose a concrete implementation approach. Be specific about which files change and how.
+Read the relevant code using your harness's native file-reading and search tools (read, grep/glob, and the like) rather than shell pipelines — hand-rolled `find … | xargs`, `grep ; awk`, or redirection shapes trigger permission prompts that cannot be permanently allowed. Then propose a concrete implementation approach, specific about which files change and how.
 
 ### Step 2 — HUMAN GATE
 
@@ -222,7 +212,14 @@ Show the user: `On branch feature/<name>`
 
 ### Step 5 — Write the code
 
-Now write the code. Do NOT commit anything.
+Write the code using your harness's native editing tools. Do NOT commit anything.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -317,7 +314,14 @@ git branch --show-current
 
 ### Step 5 — Write the code
 
-Continue from where work left off. Do NOT commit.
+Continue from where work left off, using your harness's native editing tools. Do NOT commit.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -336,4 +340,4 @@ When done, say: **"When you've verified locally, reply `yes` to submit, or say w
 - The issue is assigned to `@me` at creation. If you are creating a ticket on someone else's behalf, remove the assignee after creation with `gh issue edit <number> --remove-assignee @me`.
 - Apply resolved labels and milestone to every new issue. Label resolution order: per-invocation flag → pool selection from `bug, documentation, enhancement, chore` → omit `--label` entirely. Never apply a label outside `bug, documentation, enhancement, chore`.
 - Milestone resolution order: per-invocation flag → auto-detected from GitHub open milestones. Never prompt for a milestone more than once per invocation.
-<!-- generated by CodeCannon/sync.py | skill: start | adapter: codex | hash: e41e83ae | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+<!-- generated by CodeCannon/sync.py | skill: start | adapter: codex | hash: 9c1a1a62 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.agents/skills/status/SKILL.md
+++ b/.agents/skills/status/SKILL.md
@@ -7,45 +7,39 @@ description: Code Cannon: Summarize in-progress and recently completed work from
 
 ---
 
-## Step 1 — Parse arguments
+## What `/status` does
 
-First, check whether `$ARGUMENTS` contains `--milestone`, `--sprint`, or `--team`.
+`/status` prints a read-only, standup-ready snapshot of in-progress and recently completed work, then a single "what's next" suggestion. It never writes to GitHub or the working tree — it only reads and reports.
 
-**Milestone mode:** If `--milestone` or `--sprint` is present, extract everything after the flag as the milestone name (trim leading/trailing whitespace; preserve internal spaces). Ignore any other arguments. Enter milestone mode (Steps M1–M3 below) and skip Steps 2–6.
-
-Examples:
-- `--milestone Sprint 4` → milestone name = `Sprint 4`
-- `--sprint Sprint 4` → milestone name = `Sprint 4`
-- `--milestone Q2 Release` → milestone name = `Q2 Release`
-- `--milestone 12` → milestone name = `12`
-
-**Team mode:** If `--team` is present, enter team mode (Steps T1–T3 below) and skip Steps 2–6. `--team` is mutually exclusive with `--milestone`/`--sprint` and username arguments. If both are present, report the conflict and stop.
-
-**Personal mode** (no `--milestone` / `--sprint` / `--team` flag): determine:
-
-- **subject**: default `@me`. If the argument starts with `@` or is a plain word that is not a number, treat it as a GitHub username. Strip the leading `@` for `gh` commands that do not accept it (e.g. `gh pr list --author alice`); keep it for display.
-- **lookback**: default `7`. If the argument is a number (digits only), use it as the lookback window in days.
-
-No argument → subject = `@me`, lookback = `7`.
+Because it is read-only, the *shape* of its output does not matter: a differently-formatted-but-accurate summary is a fine result. Derive a clear, scannable layout yourself. What this skill pins down is the data to fetch, how to classify it, and the one piece of real opinion — the "what's next" ordering.
 
 ---
 
-## Step 2 — Fetch GitHub data (run all in parallel)
+## Step 1 — Determine mode
 
-Run these commands concurrently:
+Three mutually exclusive modes, selected from `$ARGUMENTS`:
 
-**Open PRs authored by subject:**
+- **Milestone mode** — `--milestone` or `--sprint` is present. Everything after the flag is the milestone name (a name or a number; trim outer whitespace, preserve internal spaces). Ignore other arguments. Run Steps M1–M2.
+- **Team mode** — `--team` is present. Run Steps T1–T2. `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username; if combined, report the conflict and stop.
+- **Personal mode** — no mode flag. **Subject** defaults to `@me`; a `@name` or a non-numeric word is a username (strip the leading `@` for `gh` flags that reject it, keep it for display). **Lookback** defaults to `7`; a bare number is the lookback in days.
+
+---
+
+## Step 2 — Fetch GitHub data (personal mode)
+
+Run these concurrently. If any `gh` command exits non-zero (including auth errors), report the message and stop — do not retry.
+
+**Open PRs authored by subject** — request enough fields to derive health (draft, CI, review decision, merge conflict) and staleness:
 ```bash
 gh pr list --author <subject> --state open \
   --json number,title,url,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
 ```
 
-**Recently merged PRs (last `<lookback>` days):**
+**Recently merged PRs**, filtered to those merged within `<lookback>` days:
 ```bash
 gh pr list --author <subject> --state merged --limit 20 \
   --json number,title,url,mergedAt,labels,baseRefName
 ```
-Filter the results to keep only entries where `mergedAt` is within the last `<lookback>` days.
 
 **Open issues assigned to subject:**
 ```bash
@@ -53,317 +47,103 @@ gh issue list --assignee <subject> --state open \
   --json number,title,url,labels,milestone,updatedAt
 ```
 
-**PRs requesting your review** (only when subject is `@me`):
+**PRs requesting your review** — only when subject is `@me`; skip for other users:
 ```bash
 gh pr list --search "review-requested:@me" --state open \
   --json number,title,url,author,updatedAt
 ```
-Skip this query when viewing another user's status.
 
-If any `gh` command exits with a non-zero status (including auth errors), report the error message and stop. Do not retry.
-
----
-
-## Step 3 — Fetch local git context
-
-Check if the current directory is inside a git repository:
-```bash
-git rev-parse --is-inside-work-tree
-```
-
-If yes, run:
+Also fetch local git context (skip and note if not in a git repo — `git rev-parse --is-inside-work-tree`):
 ```bash
 git log --oneline --since="<lookback> days ago"
 ```
 
-If not inside a git repo, skip this step and note it was skipped in the output.
+---
+
+## Step 3 — Classify and report (personal mode)
+
+Sort items into these buckets:
+
+- **In progress** — open PRs. Identify a linked issue from the PR body (`#N`, `closes #N`, `fixes #N`, `issue #N`) and cross-reference open issues.
+- **Done** — PRs merged within the lookback window.
+- **Up next** — open issues whose number is **not** referenced by any open PR body. (An issue linked from an open PR belongs under *In progress* with that PR, not here.)
+- **Needs your review** — the review-requested query (only when subject is `@me`).
+
+For each open PR, derive health from the JSON — draft state, CI status from `statusCheckRollup`, review state from `reviewDecision`, merge conflict from `mergeable`. Present each as a compact badge; omit a badge when it does not apply or is not configured.
+
+**Staleness:** flag any open PR or issue not updated within `14` days (a threshold of `0` disables staleness entirely). Note the last-updated date and age. This is a real config-driven rule — honor the threshold exactly.
+
+Report the buckets as a scannable summary: a heading naming the subject and lookback, a one-line count roll-up, then a section per non-empty bucket, then the local commits (or a note that git was skipped). Show labels/milestone only when present; dates as `YYYY-MM-DD`. If every GitHub bucket is empty, say so plainly for the subject and window.
+
+**Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Step 4 — Classify items
+## Step 4 — What's next (personal mode)
 
-Using the data from Steps 2 and 3, classify each item:
+After the summary, append **one** actionable suggestion. Gather the extra local state you need (current branch, `git status --porcelain`, latest tag via `git describe --tags --abbrev=0`, unreleased commit count via `git rev-list <tag>..HEAD --count`, and the current branch's PR review/check state via `gh pr view` — treat a non-zero exit as "no PR for this branch"). Skip git lookups when not in a repo.
 
-- **In progress** — open PRs. For each, attempt to identify a linked issue number from the PR body (look for `#N`, `closes #N`, `fixes #N`, `issue #N`). If found, cross-reference with open issues.
-- **Done** — merged PRs within the lookback window.
-- **Up next** — open issues that are NOT associated with any open PR (i.e. no open PR body references their issue number).
-- **Needs your review** — PRs from the review-requested query (only when subject is `@me`).
+Evaluate these conditions **in order** and use the **first** match. This ordering is the workflow's opinion about what the operator should do next — it is load-bearing, not formatting:
 
-An open issue that IS linked from an open PR body appears under "In progress" alongside that PR, not under "Up next".
+| Priority | Condition | Suggestion |
+|----------|-----------|------------|
+| 1 | On a `feature/*` branch with uncommitted changes | You have uncommitted changes on `<branch>`. When ready, run `/submit-for-review`. |
+| 2 | On a `feature/*` branch, open PR is `APPROVED` and all checks `COMPLETED` | PR #<number> is approved and checks pass. Consider running `/deploy`. |
+| 3 | On a `feature/*` branch with an open PR in any other state | PR #<number> (<title>) is open and awaiting review. |
+| 3.5 | Subject is `@me` and PRs request your review | Append to the current suggestion (or stand alone if nothing higher matched): You also have <N> PR(s) awaiting your review. |
+| 4 | On a `feature/*` branch, no open PR, clean tree | No open PR for `<branch>`. Run `/submit-for-review` to open one. |
+| 5 | On the integration branch with unreleased commits since the last tag | <N> commit(s) on `<branch>` since `<tag>`. Run `/deploy` when ready to release. |
+| 6 | No open PRs and no open issues assigned to subject | Nothing in progress. Run `/start` to begin new work. |
+| 7 | Open issues exist in "Up next" | Next up is #<number> (<title>). Run `/start <number>` to pick it up. |
 
-### 4a — Derive health badges
-
-For each open PR, derive the following badges:
-
-**Draft status:**
-- If `isDraft` is `true` → `[draft]`
-
-**CI check status** (from `statusCheckRollup`):
-- All checks have `status: COMPLETED` and `conclusion: SUCCESS` → `✅ checks passing`
-- Any check has `conclusion: FAILURE` → `❌ checks failing`
-- Checks are still running or have other states → `⏳ checks pending`
-- No checks configured → omit badge
-
-**Review decision** (from `reviewDecision`):
-- `APPROVED` → `✅ approved`
-- `CHANGES_REQUESTED` → `🔄 changes requested`
-- `REVIEW_REQUIRED` or empty → `⏳ awaiting review`
-
-**Merge conflict** (from `mergeable`):
-- `CONFLICTING` → `⚠️ conflicts`
-- `MERGEABLE` or `UNKNOWN` → omit badge
-
-### 4b — Flag stale items
-
-For each open PR and open issue, check `updatedAt`. If the item has not been updated within `14` days (default: 14; disabled when set to 0), flag it as stale. Record the last-updated date and the number of days since the last update.
-
-A stale item gets an inline `⚠️ stale (<N>d)` badge appended after any other badges.
+If none match, omit the "what's next" section. Omit it entirely in milestone mode.
 
 ---
 
-## Step 5 — Output the summary
+## Milestone mode (Steps M1–M2)
 
-Print a formatted summary. Use this structure:
-
-```
-## Status for <subject> — last <lookback> days
-
-<N> in progress · <N> done · <N> up next[ · <N> need your review]
-
-### In progress
-- #<number> <title> [<labels>] [<milestone>] [draft]
-  PR: <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>][ · <stale badge>]
-  Linked issue: #<number> (if found)
-
-### Done
-- #<number> <title> [<labels>] — merged <date>
-  PR: <url>
-
-### Needs your review
-- #<number> <title> (by @<author>)
-  PR: <url>
-
-### Up next
-- #<number> <title> [<labels>] [<milestone>][ · <stale badge>]
-  Issue: <url>
-
-### ⚠️ Stale
-- #<number> <title> — last updated <date> (<N> days ago)
-
----
-Local commits (current branch):
-<git log output, or "skipped — not in a git repo">
-```
-
-Rules:
-- **Summary counts line**: show immediately after the heading. Omit zero-count segments (e.g., if nothing is done, skip that segment). "need your review" only appears when subject is `@me` and the count is > 0.
-- **Health badges**: show on the second line of each "In progress" item, after the PR URL, separated by ` · `. Omit individual badges that don't apply (e.g., no conflict badge if mergeable).
-- **Draft badge**: show `[draft]` inline in the first line of draft PRs, before any other badges.
-- **Stale section**: a dedicated section at the bottom (before "Local commits") listing all stale items from any section, with their last-updated date and age. This gives a consolidated view. Individual items also get the inline `⚠️ stale (<N>d)` badge in their own sections.
-- **"Needs your review" section**: only shown when subject is `@me` and there are PRs requesting review. Placed between "Done" and "Up next".
-- Omit any section that has no items — do not show an empty heading.
-- Show labels only if present; show milestone only if present.
-- Dates use `YYYY-MM-DD` format.
-- If all GitHub sections are empty, print: `Nothing found for <subject> in the last <lookback> days.`
-
-Do not post, comment, write files, or take any action. Output only.
-
----
-
-## Step 6 — What's next
-
-After the status summary, append a single actionable suggestion based on local git state and the GitHub data already fetched.
-
-### 6a — Gather additional local state
-
-Run these commands (skip if not in a git repo):
-
-```bash
-git branch --show-current
-```
-
-```bash
-git status --porcelain
-```
-
-```bash
-git describe --tags --abbrev=0
-```
-
-```bash
-git rev-list <latest-tag>..HEAD --count
-```
-
-From the GitHub data fetched in Step 2, also check for the current branch's PR approval status:
-
-```bash
-gh pr view --json number,title,url,reviewDecision,statusCheckRollup \
-  --jq '{number,title,url,reviewDecision,checks: [.statusCheckRollup[]? | .status]}'
-```
-
-If `gh pr view` exits non-zero (no PR for current branch), note that there is no open PR.
-
-### 6b — Determine suggestion
-
-Evaluate the following conditions **in order**. Use the **first** match:
-
-| Priority | Condition | Output |
-|----------|-----------|--------|
-| 1 | On a `feature/*` branch with uncommitted changes (`git status --porcelain` is non-empty) | `What's next: You have uncommitted changes on \`<branch>\`. When ready, run \`/submit-for-review\`.` |
-| 2 | On a `feature/*` branch with an open PR that has `reviewDecision: APPROVED` and all status checks are `COMPLETED` | `What's next: PR #<number> is approved and checks pass. Consider running \`/deploy\`.` |
-| 3 | On a `feature/*` branch with an open PR (any other review/check state) | `What's next: PR #<number> (<title>) is open and awaiting review.` |
-| 3.5 | Subject is `@me` and there are PRs requesting your review (from Step 2 query) | Append to the current suggestion (or show standalone if no higher priority matched): `You also have <N> PR(s) awaiting your review.` |
-| 4 | On a `feature/*` branch with no open PR and clean working tree | `What's next: No open PR for \`<branch>\`. Run \`/submit-for-review\` to open one.` |
-| 5 | On the integration branch (`dev`, `develop`, or `main` when no integration branch exists) with unreleased commits (rev-list count > 0 since last tag) | `What's next: <N> commit(s) on \`<branch>\` since \`<tag>\`. Run \`/deploy\` when ready to release.` |
-| 6 | No open PRs, no open issues assigned to subject | `What's next: Nothing in progress. Run \`/start\` to begin new work.` |
-| 7 | Open issues exist in "Up next" | `What's next: Next up is #<number> (<title>). Run \`/start <number>\` to pick it up.` |
-
-If none of the above match, omit the "What's next" section entirely.
-
-### 6c — Format
-
-Print the suggestion after a horizontal rule, below the local commits section:
-
-```
----
-🧭 <suggestion text>
-```
-
-This section is omitted in milestone mode.
-
----
-
-## Milestone mode (Steps M1–M3)
-
-Only entered when `--milestone` or `--sprint` is detected in Step 1.
-
-### Step M1 — Fetch milestone issues
-
+### M1 — Fetch
 ```bash
 gh issue list --milestone "<name>" --state all --limit 200 \
   --json number,title,state,labels,assignees,url
-```
-
-If this command fails for any reason (milestone not found, auth error, etc.), report the error and stop.
-
-### Step M2 — Classify issues
-
-Fetch all open PRs to detect which issues are in progress (with health fields):
-
-```bash
 gh pr list --state open \
   --json number,title,body,baseRefName,reviewDecision,statusCheckRollup,mergeable,isDraft
 ```
+If the issue query fails (milestone not found, auth error), report and stop.
 
-Group issues into three buckets:
+### M2 — Classify and report
 
-- **Done** — `state: closed`
-- **In progress** — `state: open` AND the issue number appears in any open PR body (look for `#<number>`, `closes #<number>`, `fixes #<number>`, `related to #<number>`, `issue #<number>`)
-- **Not started** — `state: open` AND no open PR body references the issue number
+Group the milestone's issues into three buckets:
+- **Done** — `state: closed`.
+- **In progress** — open, and the issue number is referenced by some open PR body (`#N`, `closes #N`, `fixes #N`, `related to #N`, `issue #N`). This "referenced by an open PR" definition is the real rule — apply it exactly.
+- **Not started** — open, and no open PR references it.
 
-For in-progress issues, derive health badges from the linked PR using the same rules as Step 4a (check status, review decision, draft, conflict).
-
-### Step M3 — Output the summary
-
-```
-## Sprint: <name>
-
-<Y> of <total> issues closed · <Z> in progress · <W> not started
-
-### In progress (<Z>)
-- #<number> <title> [@<assignee>] [<milestone>][ [draft]]
-  <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>]
-
-### Not started (<W>)
-- #<number> <title> [@<assignee>]
-
-### Done (<Y>)
-- #<number> <title>
-```
-
-Rules:
-- Show "In progress" first, then "Not started", then "Done"
-- Show assignee only if present; omit if unassigned
-- Show URLs only for in-progress items; omit URLs for closed issues
-- Show health badges on in-progress items (same derivation as Step 4a)
-- If a section has no items, omit it entirely
-
-Do not post, comment, write files, or take any action. Output only.
+Derive health badges for in-progress issues from their linked PR (same fields as personal mode). Report as a scannable summary titled with the milestone name and a closed/in-progress/not-started roll-up. Show assignees and URLs where they add value; omit empty buckets. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Team mode (Steps T1–T3)
+## Team mode (Steps T1–T2)
 
-Only entered when `--team` is detected in Step 1.
-
-### Step T1 — Fetch all open work (run both in parallel)
-
+### T1 — Fetch (run both concurrently)
 ```bash
 gh pr list --state open --limit 100 \
   --json number,title,url,author,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
-```
-
-```bash
 gh issue list --state open --limit 200 \
   --json number,title,url,assignees,labels,milestone,updatedAt
 ```
+If either fails, report and stop.
 
-If either command fails, report the error and stop.
+### T2 — Group and report
 
-### Step T2 — Group and classify
-
-Group items by person:
-- PRs are grouped by `author.login`
-- Issues are grouped by assignee (first assignee if multiple). Issues with no assignee go into an "Unassigned" group.
-
-Within each person's group, classify items the same way as personal mode (Step 4):
-- **In progress** — open PRs (and linked issues)
-- **Up next** — open issues not linked from any open PR
-
-Derive health badges (Step 4a) and flag stale items (Step 4b) for all items.
-
-### Step T3 — Output the team summary
-
-```
-## Team status
-
-<N> open PRs · <N> open issues · <N> people
-
-### @<person> (<N> in progress, <N> up next)
-- #<number> <title> — PR <check badge> · <review badge>[ · <conflict badge>][ · <stale badge>][ [draft]]
-  <url>
-- #<number> <title> [up next][ · <stale badge>]
-
-### @<person> (<N> in progress, <N> up next)
-...
-
-### Unassigned (<N>)
-- #<number> <title>
-  <url>
-
-### ⚠️ Stale
-- #<number> <title> (@<person>) — last updated <date> (<N> days ago)
-```
-
-Rules:
-- Sort people alphabetically by username
-- Within each person, show in-progress items first, then up-next items
-- Show health badges on PR items (same format as personal mode)
-- Show `[draft]` on draft PRs
-- Tag up-next items with `[up next]` for visual distinction
-- "Unassigned" section appears at the bottom, only if there are unassigned issues
-- "Stale" section consolidates all stale items across all people
-- Omit any section or group with no items
-- No "What's next" section in team mode
-
-Do not post, comment, write files, or take any action. Output only.
+Group by person: PRs by `author.login`; issues by first assignee (unassigned issues into an "Unassigned" group). Within each person, classify as personal mode does — **in progress** (open PRs and their linked issues) and **up next** (open issues not referenced by any open PR) — and derive health badges plus staleness. Report per-person sections with in-progress items first, an "Unassigned" section if any, and a consolidated stale section. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
 ## Hard rules
 
-- Never write to GitHub (no comments, labels, issue updates, or PR changes).
-- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately.
-- Do not retry failed commands.
-- Strip the leading `@` from the subject when passing to `gh` flags that do not accept it.
-<!-- generated by CodeCannon/sync.py | skill: status | adapter: codex | hash: 5832e667 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+- Never write to GitHub (no comments, labels, issue updates, or PR changes) and never touch the working tree. Output only.
+- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately. Do not retry.
+- Strip the leading `@` from the subject when passing to `gh` flags that reject it.
+- `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username.
+- The `14` threshold is config-driven; `0` disables staleness. The "what's next" priority ordering is fixed — evaluate top to bottom, first match wins.
+<!-- generated by CodeCannon/sync.py | skill: status | adapter: codex | hash: beebb032 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -4,25 +4,24 @@ Code Cannon: Bump the project version, create a GitHub Release, and promote to p
 
 ## What `/deploy` does
 
-`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote to production).
+`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote the deploy branch to production first).
+
+The branching mode changes the shape of the release: in **trunk mode** (`BRANCH_PROD` only) `/deploy` tags and releases the current branch directly; in **multi-branch mode** (`BRANCH_DEV` set, optionally with `BRANCH_TEST`) it first opens and merges a release PR from the deploy branch into production, and that merge is what closes the linked issues.
 
 ---
 
-## Step 1 — Verify branch
+## Step 1 — Verify branch and sync
 
-Run:
-```bash
-git branch --show-current
-```
+Run `git branch --show-current`. The **deploy branch** for this project is:
 
-Required branch: `dev` (two-branch mode).
+`dev` (two-branch mode).
 
-If not on the required branch, abort and say: "Switch to `<required-branch>` before running `/deploy`."
+If not on the deploy branch, abort: "Switch to `<deploy-branch>` before running `/deploy`."
 
-Sync to the remote before proceeding. The script below guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<base>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from CodeCannon's own merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they get silently discarded.
+Then sync it to the remote. The script guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<deploy-branch>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they are silently discarded.
 
 ```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py dev
+python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py <deploy-branch>
 ```
 
 If the script exits non-zero, stop and resolve the issue it reports before continuing.
@@ -31,87 +30,35 @@ If the script exits non-zero, stop and resolve the issue it reports before conti
 
 ## Step 2 — Check current state
 
-### Find the latest version tag
+Find the latest version tag (`git describe --tags --abbrev=0`; if none, note this is the first release) and read the current version with `cat VERSION`.
+
+Show the merge commits (and their PRs) since the last tag. The range depends on the mode:
 
 ```bash
-git describe --tags --abbrev=0
+git log main..<deploy-branch> --merges --pretty=format:"%s"
 ```
 
-If no tag exists, note this is the first release.
+Merge-commit subjects have the form `Merge pull request #N from branch/name` — parse the PR numbers, then retrieve each body with `gh pr view <N> --json number,title,body`.
 
-### Read current version
+From those PR bodies, compile the release's issue links:
 
-```bash
-cat VERSION
-```
+Keep closing keywords and context references **separate — do not merge them into one set**:
 
-### Show commits since last tag
+- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines so they can be reproduced verbatim in the release PR body.
+- **Reference set** — issues mentioned only via `Related to #N` or the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the human gate surfaces it so you can manually close any straggler that should have closed.
+- **PRs included** (number + title).
 
-If a previous tag exists, show what's on the branch since that tag:
+Also check for open unmerged PRs (`gh pr list --state open --json number,title,headRefName`).
 
-```bash
-git log main..dev --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
-
-Extract closing keywords **separately** from context references — do **not** merge them into a single set:
-
-- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These issues will auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines it contained so they can be reproduced verbatim in the release PR body.
-- **Reference set** — issues mentioned only via `Related to #N`, or via the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the HUMAN GATE surfaces it so you can manually close any straggler that should have been a `Closes`.
-
-Compile:
-- List of PRs included (number + title)
-- Close set and reference set, kept distinct
-
-### Check for open unmerged PRs
-
-```bash
-gh pr list --state open --json number,title,headRefName
-```
-
-### Present the summary
-
-Tell the user:
-
-```
-Current version: X.Y.Z
-Latest tag: vX.Y.Z
-
-Commits/PRs since last tag:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
-
-Open PRs not yet merged:
-  #19 — Add dark mode (feature/dark-mode)
-
-Would you like to bump the version before deploying?
-  - **patch** → X.Y.C
-  - **minor** → X.B.0
-  - **major** → A.0.0
-  - **specific** → enter a version number
-  - **skip** → proceed to release with the latest existing tag
-```
-
-Wait for their response.
+Present a summary — current version, latest tag, the PRs/issues since that tag, any open PRs — and ask whether to bump the version before deploying (patch → X.Y.C, minor → X.B.0, major → A.0.0, a specific version, or skip to release the latest existing tag). Wait for their response.
 
 ---
 
 ## Step 3 — Version bump (if requested)
 
-If the user chose to skip, find the latest version tag in the branch history:
-```bash
-git describe --tags --abbrev=0
-```
+If the user chose **skip**, use the latest existing tag (`git describe --tags --abbrev=0`) as the release version. If none exists (first release), warn "No version tag found. You must bump the version before deploying." and return to the bump prompt.
 
-If no tag is found at all (first release), warn: "No version tag found. You must bump the version before deploying." Return to the version bump prompt. Otherwise, use the tag found as the release version.
-
-If the user chose a bump level, map their response to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it for the release step.
+If the user chose a bump level, map it to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it as `<new-version>`.
 
 | User says | `--bump-cmd` |
 |---|---|
@@ -126,59 +73,37 @@ python3 CodeCannon/skills/github-agile/scripts/bump-and-tag.py \
   --version-read-cmd "cat VERSION"
 ```
 
-If the script exits non-zero, stop and resolve the issue it reports before continuing. On success, the version printed on stdout is the new version — use it as `<new-version>` in subsequent steps.
+If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
 ---
 
 ## Step 4 — Compute release contents
 
-Determine the version tag (either from the bump just performed, or from the existing HEAD tag if the user skipped bumping).
+Determine the release version tag (from the bump just performed, or the existing HEAD tag if the user skipped). Find the previous tag for the changelog range: `git describe --abbrev=0 <version-tag>^`.
 
-Find the previous tag to determine the range:
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
+Reuse the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch as needed.
 
 ---
 
 ## Step 5 — HUMAN GATE
 
-Show the user the release summary. Example format:
+Show the release summary — the target version, the PRs included, and the issue links:
 
-```
-Ready to release vX.Y.Z to production.
+- Issues that will **close** on merge (the close set, reproduced verbatim from constituent PRs).
+- Issues **referenced but not closing** (the reference set — confirm none of these should actually close).
 
-PRs included:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
+Confirm the deploy branch has been tested:
+"Have you tested all of the above on preview? Type 'release' to confirm."
 
-Issues that will close on merge (Closes #N, reproduced verbatim from constituent PRs):
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
-
-Issues referenced but NOT closing (Related to #N / legacy Issue #N — confirm none of these should actually close):
-  #20 — Tighten error copy on the upload form
-
-Have you tested all of the above on preview? Type 'release' to confirm.
-```
-
-Wait for the user to type "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
+Wait for "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
 
 ---
 
-## Step 6 — Create PR: `dev` → `main`
+## Step 6 — Promote: `<deploy-branch>` → `main`
 
-First, create a temp directory for this invocation:
+Create a temp directory for this invocation (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`) and note the returned path — use it for all temp files here.
 
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
+Use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
 
 ```markdown
 Release vX.Y.Z
@@ -193,53 +118,31 @@ Closes #15
 Related to #20
 ```
 
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
+Reproduce **every** `Closes #N` line from the close set — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear without triggering an auto-close; if the reference set is empty, omit the `Related to` lines entirely.
 
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
+Create the PR (do NOT use `--body`, `--body-file -`, or heredocs), with `--head` set to the deploy branch:
 
 ```bash
-gh pr create --base main --head dev \
+gh pr create --base main --head <deploy-branch> \
   --title "Release vX.Y.Z" \
   --body-file <tmpdir>/release_pr_body.md
 ```
 
-Note the PR number from the output.
+> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close. The `Closes #N` lines auto-close the linked issues because this PR merges into `main` (the default branch).
 
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `main` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
+Then merge. Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge <pr-number> --merge` directly.
 
 ---
 
-## Step 7 — Merge
+## Step 7 — Create the GitHub Release
 
-Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
+**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action; the confirmation from Step 5 authorized the promotion, but the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
 
 > Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
 
 Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
 
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
+The version tag and PR/issue list are already known; the previous tag comes from Step 4 (if there is no previous tag, omit the "Full changelog" line). Create a temp directory if you haven't already (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`), then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
 
 ```markdown
 ## Changes
@@ -250,7 +153,7 @@ Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (sam
 **Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
 ```
 
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
+Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`; if a PR had no linked issue, use just the PR title. Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
 
 ```bash
 gh release create <version-tag> \
@@ -258,15 +161,11 @@ gh release create <version-tag> \
   --notes-file <tmpdir>/release_notes.md
 ```
 
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
+Note the release URL from the output.
 
 ---
 
-## Step 9 — Report
+## Step 8 — Report
 
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
-<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: claude | hash: 790acdbf | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+Tell the user: "Released vX.Y.Z. Linked issues are closed. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
+<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: claude | hash: 8f580805 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -22,12 +22,10 @@ Otherwise → go to **Case A: New work**.
 
 > **Execution order:** Resolve labels and milestones **now**, before entering Case A Step 1. If milestone auto-detection requires a user prompt (2+ open milestones), that prompt happens here — not later during issue creation. By the time you reach Step 2's human gate, all metadata must already be resolved so that Step 3 can proceed without re-prompting.
 
-The argument string may contain optional inline flags after the description. Parse as follows:
+The description may be followed by optional flags — `--label`/`-l` and `--milestone`/`-m`, in any order. Separate the description from the flags yourself; the flags carry these meanings:
 
-1. **Identify flags** — scan for the first token that starts with `--label`, `-l`, `--milestone`, or `-m`. Everything before it is the **description**. Everything from the first flag onward is **flags**.
-2. **`--label <value>` / `-l <value>`** — comma-separated label string (e.g. `bug` or `enhancement,ux`). If provided, it **bypasses label auto-selection entirely** for this invocation — use the value verbatim. Labels containing spaces must be quoted (e.g. `--label "good first issue"`).
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). Pass the value as-is; GitHub accepts both names and numbers.
-4. **Flags may appear in any order** after the description.
+- **`--label <value>` / `-l <value>`** — a comma-separated label string used **verbatim**, bypassing label auto-selection entirely for this invocation. Quote values containing spaces (e.g. `--label "good first issue"`).
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number (GitHub accepts both names and numbers).
 
 **Label resolution (three-tier, Case A only):**
 
@@ -51,14 +49,6 @@ After parsing flags, determine the active milestone in this order:
    - **0 results** → no milestone; proceed without `--milestone`.
    - **1 result** → use its title silently. Inform the user inline: `(milestone: <title>)`.
    - **2+ results** → show the numbered list, ask once: **"Multiple open milestones — which should this issue go under? (enter a number or title, or 'none')"**. Accept milestone number, title, or "none"/"skip". Wait for response before continuing.
-
-**Examples:**
-
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
 
 > Replace vs append: flags **replace** auto-selection entirely, they do not append. This avoids silent label duplication and milestone conflicts.
 
@@ -97,7 +87,7 @@ If on any other branch → proceed to Case A or Case B as determined by the `$AR
 
 ### Step 1 — Investigate
 
-Read the relevant code. Propose a concrete implementation approach. Be specific about which files change and how.
+Read the relevant code using your harness's native file-reading and search tools (read, grep/glob, and the like) rather than shell pipelines — hand-rolled `find … | xargs`, `grep ; awk`, or redirection shapes trigger permission prompts that cannot be permanently allowed. Then propose a concrete implementation approach, specific about which files change and how.
 
 ### Step 2 — HUMAN GATE
 
@@ -217,7 +207,14 @@ Show the user: `On branch feature/<name>`
 
 ### Step 5 — Write the code
 
-Now write the code. Do NOT commit anything.
+Write the code using your harness's native editing tools. Do NOT commit anything.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -312,7 +309,14 @@ git branch --show-current
 
 ### Step 5 — Write the code
 
-Continue from where work left off. Do NOT commit.
+Continue from where work left off, using your harness's native editing tools. Do NOT commit.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -331,4 +335,4 @@ When done, say: **"When you've verified locally, reply `yes` to submit, or say w
 - The issue is assigned to `@me` at creation. If you are creating a ticket on someone else's behalf, remove the assignee after creation with `gh issue edit <number> --remove-assignee @me`.
 - Apply resolved labels and milestone to every new issue. Label resolution order: per-invocation flag → pool selection from `bug, documentation, enhancement, chore` → omit `--label` entirely. Never apply a label outside `bug, documentation, enhancement, chore`.
 - Milestone resolution order: per-invocation flag → auto-detected from GitHub open milestones. Never prompt for a milestone more than once per invocation.
-<!-- generated by CodeCannon/sync.py | skill: start | adapter: claude | hash: 2c9789e5 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+<!-- generated by CodeCannon/sync.py | skill: start | adapter: claude | hash: 357ff5d9 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -2,45 +2,39 @@ Code Cannon: Summarize in-progress and recently completed work from GitHub and g
 
 ---
 
-## Step 1 — Parse arguments
+## What `/status` does
 
-First, check whether `$ARGUMENTS` contains `--milestone`, `--sprint`, or `--team`.
+`/status` prints a read-only, standup-ready snapshot of in-progress and recently completed work, then a single "what's next" suggestion. It never writes to GitHub or the working tree — it only reads and reports.
 
-**Milestone mode:** If `--milestone` or `--sprint` is present, extract everything after the flag as the milestone name (trim leading/trailing whitespace; preserve internal spaces). Ignore any other arguments. Enter milestone mode (Steps M1–M3 below) and skip Steps 2–6.
-
-Examples:
-- `--milestone Sprint 4` → milestone name = `Sprint 4`
-- `--sprint Sprint 4` → milestone name = `Sprint 4`
-- `--milestone Q2 Release` → milestone name = `Q2 Release`
-- `--milestone 12` → milestone name = `12`
-
-**Team mode:** If `--team` is present, enter team mode (Steps T1–T3 below) and skip Steps 2–6. `--team` is mutually exclusive with `--milestone`/`--sprint` and username arguments. If both are present, report the conflict and stop.
-
-**Personal mode** (no `--milestone` / `--sprint` / `--team` flag): determine:
-
-- **subject**: default `@me`. If the argument starts with `@` or is a plain word that is not a number, treat it as a GitHub username. Strip the leading `@` for `gh` commands that do not accept it (e.g. `gh pr list --author alice`); keep it for display.
-- **lookback**: default `7`. If the argument is a number (digits only), use it as the lookback window in days.
-
-No argument → subject = `@me`, lookback = `7`.
+Because it is read-only, the *shape* of its output does not matter: a differently-formatted-but-accurate summary is a fine result. Derive a clear, scannable layout yourself. What this skill pins down is the data to fetch, how to classify it, and the one piece of real opinion — the "what's next" ordering.
 
 ---
 
-## Step 2 — Fetch GitHub data (run all in parallel)
+## Step 1 — Determine mode
 
-Run these commands concurrently:
+Three mutually exclusive modes, selected from `$ARGUMENTS`:
 
-**Open PRs authored by subject:**
+- **Milestone mode** — `--milestone` or `--sprint` is present. Everything after the flag is the milestone name (a name or a number; trim outer whitespace, preserve internal spaces). Ignore other arguments. Run Steps M1–M2.
+- **Team mode** — `--team` is present. Run Steps T1–T2. `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username; if combined, report the conflict and stop.
+- **Personal mode** — no mode flag. **Subject** defaults to `@me`; a `@name` or a non-numeric word is a username (strip the leading `@` for `gh` flags that reject it, keep it for display). **Lookback** defaults to `7`; a bare number is the lookback in days.
+
+---
+
+## Step 2 — Fetch GitHub data (personal mode)
+
+Run these concurrently. If any `gh` command exits non-zero (including auth errors), report the message and stop — do not retry.
+
+**Open PRs authored by subject** — request enough fields to derive health (draft, CI, review decision, merge conflict) and staleness:
 ```bash
 gh pr list --author <subject> --state open \
   --json number,title,url,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
 ```
 
-**Recently merged PRs (last `<lookback>` days):**
+**Recently merged PRs**, filtered to those merged within `<lookback>` days:
 ```bash
 gh pr list --author <subject> --state merged --limit 20 \
   --json number,title,url,mergedAt,labels,baseRefName
 ```
-Filter the results to keep only entries where `mergedAt` is within the last `<lookback>` days.
 
 **Open issues assigned to subject:**
 ```bash
@@ -48,317 +42,103 @@ gh issue list --assignee <subject> --state open \
   --json number,title,url,labels,milestone,updatedAt
 ```
 
-**PRs requesting your review** (only when subject is `@me`):
+**PRs requesting your review** — only when subject is `@me`; skip for other users:
 ```bash
 gh pr list --search "review-requested:@me" --state open \
   --json number,title,url,author,updatedAt
 ```
-Skip this query when viewing another user's status.
 
-If any `gh` command exits with a non-zero status (including auth errors), report the error message and stop. Do not retry.
-
----
-
-## Step 3 — Fetch local git context
-
-Check if the current directory is inside a git repository:
-```bash
-git rev-parse --is-inside-work-tree
-```
-
-If yes, run:
+Also fetch local git context (skip and note if not in a git repo — `git rev-parse --is-inside-work-tree`):
 ```bash
 git log --oneline --since="<lookback> days ago"
 ```
 
-If not inside a git repo, skip this step and note it was skipped in the output.
+---
+
+## Step 3 — Classify and report (personal mode)
+
+Sort items into these buckets:
+
+- **In progress** — open PRs. Identify a linked issue from the PR body (`#N`, `closes #N`, `fixes #N`, `issue #N`) and cross-reference open issues.
+- **Done** — PRs merged within the lookback window.
+- **Up next** — open issues whose number is **not** referenced by any open PR body. (An issue linked from an open PR belongs under *In progress* with that PR, not here.)
+- **Needs your review** — the review-requested query (only when subject is `@me`).
+
+For each open PR, derive health from the JSON — draft state, CI status from `statusCheckRollup`, review state from `reviewDecision`, merge conflict from `mergeable`. Present each as a compact badge; omit a badge when it does not apply or is not configured.
+
+**Staleness:** flag any open PR or issue not updated within `14` days (a threshold of `0` disables staleness entirely). Note the last-updated date and age. This is a real config-driven rule — honor the threshold exactly.
+
+Report the buckets as a scannable summary: a heading naming the subject and lookback, a one-line count roll-up, then a section per non-empty bucket, then the local commits (or a note that git was skipped). Show labels/milestone only when present; dates as `YYYY-MM-DD`. If every GitHub bucket is empty, say so plainly for the subject and window.
+
+**Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Step 4 — Classify items
+## Step 4 — What's next (personal mode)
 
-Using the data from Steps 2 and 3, classify each item:
+After the summary, append **one** actionable suggestion. Gather the extra local state you need (current branch, `git status --porcelain`, latest tag via `git describe --tags --abbrev=0`, unreleased commit count via `git rev-list <tag>..HEAD --count`, and the current branch's PR review/check state via `gh pr view` — treat a non-zero exit as "no PR for this branch"). Skip git lookups when not in a repo.
 
-- **In progress** — open PRs. For each, attempt to identify a linked issue number from the PR body (look for `#N`, `closes #N`, `fixes #N`, `issue #N`). If found, cross-reference with open issues.
-- **Done** — merged PRs within the lookback window.
-- **Up next** — open issues that are NOT associated with any open PR (i.e. no open PR body references their issue number).
-- **Needs your review** — PRs from the review-requested query (only when subject is `@me`).
+Evaluate these conditions **in order** and use the **first** match. This ordering is the workflow's opinion about what the operator should do next — it is load-bearing, not formatting:
 
-An open issue that IS linked from an open PR body appears under "In progress" alongside that PR, not under "Up next".
+| Priority | Condition | Suggestion |
+|----------|-----------|------------|
+| 1 | On a `feature/*` branch with uncommitted changes | You have uncommitted changes on `<branch>`. When ready, run `/submit-for-review`. |
+| 2 | On a `feature/*` branch, open PR is `APPROVED` and all checks `COMPLETED` | PR #<number> is approved and checks pass. Consider running `/deploy`. |
+| 3 | On a `feature/*` branch with an open PR in any other state | PR #<number> (<title>) is open and awaiting review. |
+| 3.5 | Subject is `@me` and PRs request your review | Append to the current suggestion (or stand alone if nothing higher matched): You also have <N> PR(s) awaiting your review. |
+| 4 | On a `feature/*` branch, no open PR, clean tree | No open PR for `<branch>`. Run `/submit-for-review` to open one. |
+| 5 | On the integration branch with unreleased commits since the last tag | <N> commit(s) on `<branch>` since `<tag>`. Run `/deploy` when ready to release. |
+| 6 | No open PRs and no open issues assigned to subject | Nothing in progress. Run `/start` to begin new work. |
+| 7 | Open issues exist in "Up next" | Next up is #<number> (<title>). Run `/start <number>` to pick it up. |
 
-### 4a — Derive health badges
-
-For each open PR, derive the following badges:
-
-**Draft status:**
-- If `isDraft` is `true` → `[draft]`
-
-**CI check status** (from `statusCheckRollup`):
-- All checks have `status: COMPLETED` and `conclusion: SUCCESS` → `✅ checks passing`
-- Any check has `conclusion: FAILURE` → `❌ checks failing`
-- Checks are still running or have other states → `⏳ checks pending`
-- No checks configured → omit badge
-
-**Review decision** (from `reviewDecision`):
-- `APPROVED` → `✅ approved`
-- `CHANGES_REQUESTED` → `🔄 changes requested`
-- `REVIEW_REQUIRED` or empty → `⏳ awaiting review`
-
-**Merge conflict** (from `mergeable`):
-- `CONFLICTING` → `⚠️ conflicts`
-- `MERGEABLE` or `UNKNOWN` → omit badge
-
-### 4b — Flag stale items
-
-For each open PR and open issue, check `updatedAt`. If the item has not been updated within `14` days (default: 14; disabled when set to 0), flag it as stale. Record the last-updated date and the number of days since the last update.
-
-A stale item gets an inline `⚠️ stale (<N>d)` badge appended after any other badges.
+If none match, omit the "what's next" section. Omit it entirely in milestone mode.
 
 ---
 
-## Step 5 — Output the summary
+## Milestone mode (Steps M1–M2)
 
-Print a formatted summary. Use this structure:
-
-```
-## Status for <subject> — last <lookback> days
-
-<N> in progress · <N> done · <N> up next[ · <N> need your review]
-
-### In progress
-- #<number> <title> [<labels>] [<milestone>] [draft]
-  PR: <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>][ · <stale badge>]
-  Linked issue: #<number> (if found)
-
-### Done
-- #<number> <title> [<labels>] — merged <date>
-  PR: <url>
-
-### Needs your review
-- #<number> <title> (by @<author>)
-  PR: <url>
-
-### Up next
-- #<number> <title> [<labels>] [<milestone>][ · <stale badge>]
-  Issue: <url>
-
-### ⚠️ Stale
-- #<number> <title> — last updated <date> (<N> days ago)
-
----
-Local commits (current branch):
-<git log output, or "skipped — not in a git repo">
-```
-
-Rules:
-- **Summary counts line**: show immediately after the heading. Omit zero-count segments (e.g., if nothing is done, skip that segment). "need your review" only appears when subject is `@me` and the count is > 0.
-- **Health badges**: show on the second line of each "In progress" item, after the PR URL, separated by ` · `. Omit individual badges that don't apply (e.g., no conflict badge if mergeable).
-- **Draft badge**: show `[draft]` inline in the first line of draft PRs, before any other badges.
-- **Stale section**: a dedicated section at the bottom (before "Local commits") listing all stale items from any section, with their last-updated date and age. This gives a consolidated view. Individual items also get the inline `⚠️ stale (<N>d)` badge in their own sections.
-- **"Needs your review" section**: only shown when subject is `@me` and there are PRs requesting review. Placed between "Done" and "Up next".
-- Omit any section that has no items — do not show an empty heading.
-- Show labels only if present; show milestone only if present.
-- Dates use `YYYY-MM-DD` format.
-- If all GitHub sections are empty, print: `Nothing found for <subject> in the last <lookback> days.`
-
-Do not post, comment, write files, or take any action. Output only.
-
----
-
-## Step 6 — What's next
-
-After the status summary, append a single actionable suggestion based on local git state and the GitHub data already fetched.
-
-### 6a — Gather additional local state
-
-Run these commands (skip if not in a git repo):
-
-```bash
-git branch --show-current
-```
-
-```bash
-git status --porcelain
-```
-
-```bash
-git describe --tags --abbrev=0
-```
-
-```bash
-git rev-list <latest-tag>..HEAD --count
-```
-
-From the GitHub data fetched in Step 2, also check for the current branch's PR approval status:
-
-```bash
-gh pr view --json number,title,url,reviewDecision,statusCheckRollup \
-  --jq '{number,title,url,reviewDecision,checks: [.statusCheckRollup[]? | .status]}'
-```
-
-If `gh pr view` exits non-zero (no PR for current branch), note that there is no open PR.
-
-### 6b — Determine suggestion
-
-Evaluate the following conditions **in order**. Use the **first** match:
-
-| Priority | Condition | Output |
-|----------|-----------|--------|
-| 1 | On a `feature/*` branch with uncommitted changes (`git status --porcelain` is non-empty) | `What's next: You have uncommitted changes on \`<branch>\`. When ready, run \`/submit-for-review\`.` |
-| 2 | On a `feature/*` branch with an open PR that has `reviewDecision: APPROVED` and all status checks are `COMPLETED` | `What's next: PR #<number> is approved and checks pass. Consider running \`/deploy\`.` |
-| 3 | On a `feature/*` branch with an open PR (any other review/check state) | `What's next: PR #<number> (<title>) is open and awaiting review.` |
-| 3.5 | Subject is `@me` and there are PRs requesting your review (from Step 2 query) | Append to the current suggestion (or show standalone if no higher priority matched): `You also have <N> PR(s) awaiting your review.` |
-| 4 | On a `feature/*` branch with no open PR and clean working tree | `What's next: No open PR for \`<branch>\`. Run \`/submit-for-review\` to open one.` |
-| 5 | On the integration branch (`dev`, `develop`, or `main` when no integration branch exists) with unreleased commits (rev-list count > 0 since last tag) | `What's next: <N> commit(s) on \`<branch>\` since \`<tag>\`. Run \`/deploy\` when ready to release.` |
-| 6 | No open PRs, no open issues assigned to subject | `What's next: Nothing in progress. Run \`/start\` to begin new work.` |
-| 7 | Open issues exist in "Up next" | `What's next: Next up is #<number> (<title>). Run \`/start <number>\` to pick it up.` |
-
-If none of the above match, omit the "What's next" section entirely.
-
-### 6c — Format
-
-Print the suggestion after a horizontal rule, below the local commits section:
-
-```
----
-🧭 <suggestion text>
-```
-
-This section is omitted in milestone mode.
-
----
-
-## Milestone mode (Steps M1–M3)
-
-Only entered when `--milestone` or `--sprint` is detected in Step 1.
-
-### Step M1 — Fetch milestone issues
-
+### M1 — Fetch
 ```bash
 gh issue list --milestone "<name>" --state all --limit 200 \
   --json number,title,state,labels,assignees,url
-```
-
-If this command fails for any reason (milestone not found, auth error, etc.), report the error and stop.
-
-### Step M2 — Classify issues
-
-Fetch all open PRs to detect which issues are in progress (with health fields):
-
-```bash
 gh pr list --state open \
   --json number,title,body,baseRefName,reviewDecision,statusCheckRollup,mergeable,isDraft
 ```
+If the issue query fails (milestone not found, auth error), report and stop.
 
-Group issues into three buckets:
+### M2 — Classify and report
 
-- **Done** — `state: closed`
-- **In progress** — `state: open` AND the issue number appears in any open PR body (look for `#<number>`, `closes #<number>`, `fixes #<number>`, `related to #<number>`, `issue #<number>`)
-- **Not started** — `state: open` AND no open PR body references the issue number
+Group the milestone's issues into three buckets:
+- **Done** — `state: closed`.
+- **In progress** — open, and the issue number is referenced by some open PR body (`#N`, `closes #N`, `fixes #N`, `related to #N`, `issue #N`). This "referenced by an open PR" definition is the real rule — apply it exactly.
+- **Not started** — open, and no open PR references it.
 
-For in-progress issues, derive health badges from the linked PR using the same rules as Step 4a (check status, review decision, draft, conflict).
-
-### Step M3 — Output the summary
-
-```
-## Sprint: <name>
-
-<Y> of <total> issues closed · <Z> in progress · <W> not started
-
-### In progress (<Z>)
-- #<number> <title> [@<assignee>] [<milestone>][ [draft]]
-  <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>]
-
-### Not started (<W>)
-- #<number> <title> [@<assignee>]
-
-### Done (<Y>)
-- #<number> <title>
-```
-
-Rules:
-- Show "In progress" first, then "Not started", then "Done"
-- Show assignee only if present; omit if unassigned
-- Show URLs only for in-progress items; omit URLs for closed issues
-- Show health badges on in-progress items (same derivation as Step 4a)
-- If a section has no items, omit it entirely
-
-Do not post, comment, write files, or take any action. Output only.
+Derive health badges for in-progress issues from their linked PR (same fields as personal mode). Report as a scannable summary titled with the milestone name and a closed/in-progress/not-started roll-up. Show assignees and URLs where they add value; omit empty buckets. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Team mode (Steps T1–T3)
+## Team mode (Steps T1–T2)
 
-Only entered when `--team` is detected in Step 1.
-
-### Step T1 — Fetch all open work (run both in parallel)
-
+### T1 — Fetch (run both concurrently)
 ```bash
 gh pr list --state open --limit 100 \
   --json number,title,url,author,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
-```
-
-```bash
 gh issue list --state open --limit 200 \
   --json number,title,url,assignees,labels,milestone,updatedAt
 ```
+If either fails, report and stop.
 
-If either command fails, report the error and stop.
+### T2 — Group and report
 
-### Step T2 — Group and classify
-
-Group items by person:
-- PRs are grouped by `author.login`
-- Issues are grouped by assignee (first assignee if multiple). Issues with no assignee go into an "Unassigned" group.
-
-Within each person's group, classify items the same way as personal mode (Step 4):
-- **In progress** — open PRs (and linked issues)
-- **Up next** — open issues not linked from any open PR
-
-Derive health badges (Step 4a) and flag stale items (Step 4b) for all items.
-
-### Step T3 — Output the team summary
-
-```
-## Team status
-
-<N> open PRs · <N> open issues · <N> people
-
-### @<person> (<N> in progress, <N> up next)
-- #<number> <title> — PR <check badge> · <review badge>[ · <conflict badge>][ · <stale badge>][ [draft]]
-  <url>
-- #<number> <title> [up next][ · <stale badge>]
-
-### @<person> (<N> in progress, <N> up next)
-...
-
-### Unassigned (<N>)
-- #<number> <title>
-  <url>
-
-### ⚠️ Stale
-- #<number> <title> (@<person>) — last updated <date> (<N> days ago)
-```
-
-Rules:
-- Sort people alphabetically by username
-- Within each person, show in-progress items first, then up-next items
-- Show health badges on PR items (same format as personal mode)
-- Show `[draft]` on draft PRs
-- Tag up-next items with `[up next]` for visual distinction
-- "Unassigned" section appears at the bottom, only if there are unassigned issues
-- "Stale" section consolidates all stale items across all people
-- Omit any section or group with no items
-- No "What's next" section in team mode
-
-Do not post, comment, write files, or take any action. Output only.
+Group by person: PRs by `author.login`; issues by first assignee (unassigned issues into an "Unassigned" group). Within each person, classify as personal mode does — **in progress** (open PRs and their linked issues) and **up next** (open issues not referenced by any open PR) — and derive health badges plus staleness. Report per-person sections with in-progress items first, an "Unassigned" section if any, and a consolidated stale section. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
 ## Hard rules
 
-- Never write to GitHub (no comments, labels, issue updates, or PR changes).
-- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately.
-- Do not retry failed commands.
-- Strip the leading `@` from the subject when passing to `gh` flags that do not accept it.
-<!-- generated by CodeCannon/sync.py | skill: status | adapter: claude | hash: 148f31a9 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+- Never write to GitHub (no comments, labels, issue updates, or PR changes) and never touch the working tree. Output only.
+- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately. Do not retry.
+- Strip the leading `@` from the subject when passing to `gh` flags that reject it.
+- `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username.
+- The `14` threshold is config-driven; `0` disables staleness. The "what's next" priority ordering is fixed — evaluate top to bottom, first match wins.
+<!-- generated by CodeCannon/sync.py | skill: status | adapter: claude | hash: 99c9777e | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.codecannon.yaml
+++ b/.codecannon.yaml
@@ -29,6 +29,7 @@ config:
   DEV_CMD: make dev
   ABANDON_CMD: make abandon
   CHECK_CMD: make check
+  TEST_CMD: make test
   MERGE_CMD: make merge
   DEPLOY_PREVIEW_CMD: make deploy-preview
   DEPLOY_PROD_CMD: make deploy-prod

--- a/.cursor/rules/deploy.mdc
+++ b/.cursor/rules/deploy.mdc
@@ -10,25 +10,24 @@ alwaysApply: false
 
 ## What `/deploy` does
 
-`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote to production).
+`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote the deploy branch to production first).
+
+The branching mode changes the shape of the release: in **trunk mode** (`BRANCH_PROD` only) `/deploy` tags and releases the current branch directly; in **multi-branch mode** (`BRANCH_DEV` set, optionally with `BRANCH_TEST`) it first opens and merges a release PR from the deploy branch into production, and that merge is what closes the linked issues.
 
 ---
 
-## Step 1 — Verify branch
+## Step 1 — Verify branch and sync
 
-Run:
-```bash
-git branch --show-current
-```
+Run `git branch --show-current`. The **deploy branch** for this project is:
 
-Required branch: `dev` (two-branch mode).
+`dev` (two-branch mode).
 
-If not on the required branch, abort and say: "Switch to `<required-branch>` before running `/deploy`."
+If not on the deploy branch, abort: "Switch to `<deploy-branch>` before running `/deploy`."
 
-Sync to the remote before proceeding. The script below guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<base>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from CodeCannon's own merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they get silently discarded.
+Then sync it to the remote. The script guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<deploy-branch>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they are silently discarded.
 
 ```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py dev
+python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py <deploy-branch>
 ```
 
 If the script exits non-zero, stop and resolve the issue it reports before continuing.
@@ -37,87 +36,35 @@ If the script exits non-zero, stop and resolve the issue it reports before conti
 
 ## Step 2 — Check current state
 
-### Find the latest version tag
+Find the latest version tag (`git describe --tags --abbrev=0`; if none, note this is the first release) and read the current version with `cat VERSION`.
+
+Show the merge commits (and their PRs) since the last tag. The range depends on the mode:
 
 ```bash
-git describe --tags --abbrev=0
+git log main..<deploy-branch> --merges --pretty=format:"%s"
 ```
 
-If no tag exists, note this is the first release.
+Merge-commit subjects have the form `Merge pull request #N from branch/name` — parse the PR numbers, then retrieve each body with `gh pr view <N> --json number,title,body`.
 
-### Read current version
+From those PR bodies, compile the release's issue links:
 
-```bash
-cat VERSION
-```
+Keep closing keywords and context references **separate — do not merge them into one set**:
 
-### Show commits since last tag
+- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines so they can be reproduced verbatim in the release PR body.
+- **Reference set** — issues mentioned only via `Related to #N` or the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the human gate surfaces it so you can manually close any straggler that should have closed.
+- **PRs included** (number + title).
 
-If a previous tag exists, show what's on the branch since that tag:
+Also check for open unmerged PRs (`gh pr list --state open --json number,title,headRefName`).
 
-```bash
-git log main..dev --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
-
-Extract closing keywords **separately** from context references — do **not** merge them into a single set:
-
-- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These issues will auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines it contained so they can be reproduced verbatim in the release PR body.
-- **Reference set** — issues mentioned only via `Related to #N`, or via the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the HUMAN GATE surfaces it so you can manually close any straggler that should have been a `Closes`.
-
-Compile:
-- List of PRs included (number + title)
-- Close set and reference set, kept distinct
-
-### Check for open unmerged PRs
-
-```bash
-gh pr list --state open --json number,title,headRefName
-```
-
-### Present the summary
-
-Tell the user:
-
-```
-Current version: X.Y.Z
-Latest tag: vX.Y.Z
-
-Commits/PRs since last tag:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
-
-Open PRs not yet merged:
-  #19 — Add dark mode (feature/dark-mode)
-
-Would you like to bump the version before deploying?
-  - **patch** → X.Y.C
-  - **minor** → X.B.0
-  - **major** → A.0.0
-  - **specific** → enter a version number
-  - **skip** → proceed to release with the latest existing tag
-```
-
-Wait for their response.
+Present a summary — current version, latest tag, the PRs/issues since that tag, any open PRs — and ask whether to bump the version before deploying (patch → X.Y.C, minor → X.B.0, major → A.0.0, a specific version, or skip to release the latest existing tag). Wait for their response.
 
 ---
 
 ## Step 3 — Version bump (if requested)
 
-If the user chose to skip, find the latest version tag in the branch history:
-```bash
-git describe --tags --abbrev=0
-```
+If the user chose **skip**, use the latest existing tag (`git describe --tags --abbrev=0`) as the release version. If none exists (first release), warn "No version tag found. You must bump the version before deploying." and return to the bump prompt.
 
-If no tag is found at all (first release), warn: "No version tag found. You must bump the version before deploying." Return to the version bump prompt. Otherwise, use the tag found as the release version.
-
-If the user chose a bump level, map their response to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it for the release step.
+If the user chose a bump level, map it to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it as `<new-version>`.
 
 | User says | `--bump-cmd` |
 |---|---|
@@ -132,59 +79,37 @@ python3 CodeCannon/skills/github-agile/scripts/bump-and-tag.py \
   --version-read-cmd "cat VERSION"
 ```
 
-If the script exits non-zero, stop and resolve the issue it reports before continuing. On success, the version printed on stdout is the new version — use it as `<new-version>` in subsequent steps.
+If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
 ---
 
 ## Step 4 — Compute release contents
 
-Determine the version tag (either from the bump just performed, or from the existing HEAD tag if the user skipped bumping).
+Determine the release version tag (from the bump just performed, or the existing HEAD tag if the user skipped). Find the previous tag for the changelog range: `git describe --abbrev=0 <version-tag>^`.
 
-Find the previous tag to determine the range:
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
+Reuse the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch as needed.
 
 ---
 
 ## Step 5 — HUMAN GATE
 
-Show the user the release summary. Example format:
+Show the release summary — the target version, the PRs included, and the issue links:
 
-```
-Ready to release vX.Y.Z to production.
+- Issues that will **close** on merge (the close set, reproduced verbatim from constituent PRs).
+- Issues **referenced but not closing** (the reference set — confirm none of these should actually close).
 
-PRs included:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
+Confirm the deploy branch has been tested:
+"Have you tested all of the above on preview? Type 'release' to confirm."
 
-Issues that will close on merge (Closes #N, reproduced verbatim from constituent PRs):
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
-
-Issues referenced but NOT closing (Related to #N / legacy Issue #N — confirm none of these should actually close):
-  #20 — Tighten error copy on the upload form
-
-Have you tested all of the above on preview? Type 'release' to confirm.
-```
-
-Wait for the user to type "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
+Wait for "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
 
 ---
 
-## Step 6 — Create PR: `dev` → `main`
+## Step 6 — Promote: `<deploy-branch>` → `main`
 
-First, create a temp directory for this invocation:
+Create a temp directory for this invocation (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`) and note the returned path — use it for all temp files here.
 
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
+Use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
 
 ```markdown
 Release vX.Y.Z
@@ -199,53 +124,31 @@ Closes #15
 Related to #20
 ```
 
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
+Reproduce **every** `Closes #N` line from the close set — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear without triggering an auto-close; if the reference set is empty, omit the `Related to` lines entirely.
 
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
+Create the PR (do NOT use `--body`, `--body-file -`, or heredocs), with `--head` set to the deploy branch:
 
 ```bash
-gh pr create --base main --head dev \
+gh pr create --base main --head <deploy-branch> \
   --title "Release vX.Y.Z" \
   --body-file <tmpdir>/release_pr_body.md
 ```
 
-Note the PR number from the output.
+> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close. The `Closes #N` lines auto-close the linked issues because this PR merges into `main` (the default branch).
 
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `main` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
+Then merge. Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge <pr-number> --merge` directly.
 
 ---
 
-## Step 7 — Merge
+## Step 7 — Create the GitHub Release
 
-Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
+**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action; the confirmation from Step 5 authorized the promotion, but the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
 
 > Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
 
 Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
 
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
+The version tag and PR/issue list are already known; the previous tag comes from Step 4 (if there is no previous tag, omit the "Full changelog" line). Create a temp directory if you haven't already (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`), then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
 
 ```markdown
 ## Changes
@@ -256,7 +159,7 @@ Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (sam
 **Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
 ```
 
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
+Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`; if a PR had no linked issue, use just the PR title. Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
 
 ```bash
 gh release create <version-tag> \
@@ -264,15 +167,11 @@ gh release create <version-tag> \
   --notes-file <tmpdir>/release_notes.md
 ```
 
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
+Note the release URL from the output.
 
 ---
 
-## Step 9 — Report
+## Step 8 — Report
 
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
-<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: cursor | hash: cf532b25 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+Tell the user: "Released vX.Y.Z. Linked issues are closed. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
+<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: cursor | hash: ab16e157 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.cursor/rules/start.mdc
+++ b/.cursor/rules/start.mdc
@@ -28,12 +28,10 @@ Otherwise → go to **Case A: New work**.
 
 > **Execution order:** Resolve labels and milestones **now**, before entering Case A Step 1. If milestone auto-detection requires a user prompt (2+ open milestones), that prompt happens here — not later during issue creation. By the time you reach Step 2's human gate, all metadata must already be resolved so that Step 3 can proceed without re-prompting.
 
-The argument string may contain optional inline flags after the description. Parse as follows:
+The description may be followed by optional flags — `--label`/`-l` and `--milestone`/`-m`, in any order. Separate the description from the flags yourself; the flags carry these meanings:
 
-1. **Identify flags** — scan for the first token that starts with `--label`, `-l`, `--milestone`, or `-m`. Everything before it is the **description**. Everything from the first flag onward is **flags**.
-2. **`--label <value>` / `-l <value>`** — comma-separated label string (e.g. `bug` or `enhancement,ux`). If provided, it **bypasses label auto-selection entirely** for this invocation — use the value verbatim. Labels containing spaces must be quoted (e.g. `--label "good first issue"`).
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). Pass the value as-is; GitHub accepts both names and numbers.
-4. **Flags may appear in any order** after the description.
+- **`--label <value>` / `-l <value>`** — a comma-separated label string used **verbatim**, bypassing label auto-selection entirely for this invocation. Quote values containing spaces (e.g. `--label "good first issue"`).
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number (GitHub accepts both names and numbers).
 
 **Label resolution (three-tier, Case A only):**
 
@@ -57,14 +55,6 @@ After parsing flags, determine the active milestone in this order:
    - **0 results** → no milestone; proceed without `--milestone`.
    - **1 result** → use its title silently. Inform the user inline: `(milestone: <title>)`.
    - **2+ results** → show the numbered list, ask once: **"Multiple open milestones — which should this issue go under? (enter a number or title, or 'none')"**. Accept milestone number, title, or "none"/"skip". Wait for response before continuing.
-
-**Examples:**
-
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
 
 > Replace vs append: flags **replace** auto-selection entirely, they do not append. This avoids silent label duplication and milestone conflicts.
 
@@ -103,7 +93,7 @@ If on any other branch → proceed to Case A or Case B as determined by the `$AR
 
 ### Step 1 — Investigate
 
-Read the relevant code. Propose a concrete implementation approach. Be specific about which files change and how.
+Read the relevant code using your harness's native file-reading and search tools (read, grep/glob, and the like) rather than shell pipelines — hand-rolled `find … | xargs`, `grep ; awk`, or redirection shapes trigger permission prompts that cannot be permanently allowed. Then propose a concrete implementation approach, specific about which files change and how.
 
 ### Step 2 — HUMAN GATE
 
@@ -223,7 +213,14 @@ Show the user: `On branch feature/<name>`
 
 ### Step 5 — Write the code
 
-Now write the code. Do NOT commit anything.
+Write the code using your harness's native editing tools. Do NOT commit anything.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -318,7 +315,14 @@ git branch --show-current
 
 ### Step 5 — Write the code
 
-Continue from where work left off. Do NOT commit.
+Continue from where work left off, using your harness's native editing tools. Do NOT commit.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -337,4 +341,4 @@ When done, say: **"When you've verified locally, reply `yes` to submit, or say w
 - The issue is assigned to `@me` at creation. If you are creating a ticket on someone else's behalf, remove the assignee after creation with `gh issue edit <number> --remove-assignee @me`.
 - Apply resolved labels and milestone to every new issue. Label resolution order: per-invocation flag → pool selection from `bug, documentation, enhancement, chore` → omit `--label` entirely. Never apply a label outside `bug, documentation, enhancement, chore`.
 - Milestone resolution order: per-invocation flag → auto-detected from GitHub open milestones. Never prompt for a milestone more than once per invocation.
-<!-- generated by CodeCannon/sync.py | skill: start | adapter: cursor | hash: de29216a | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+<!-- generated by CodeCannon/sync.py | skill: start | adapter: cursor | hash: 6606010e | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.cursor/rules/status.mdc
+++ b/.cursor/rules/status.mdc
@@ -8,45 +8,39 @@ alwaysApply: false
 
 ---
 
-## Step 1 — Parse arguments
+## What `/status` does
 
-First, check whether `$ARGUMENTS` contains `--milestone`, `--sprint`, or `--team`.
+`/status` prints a read-only, standup-ready snapshot of in-progress and recently completed work, then a single "what's next" suggestion. It never writes to GitHub or the working tree — it only reads and reports.
 
-**Milestone mode:** If `--milestone` or `--sprint` is present, extract everything after the flag as the milestone name (trim leading/trailing whitespace; preserve internal spaces). Ignore any other arguments. Enter milestone mode (Steps M1–M3 below) and skip Steps 2–6.
-
-Examples:
-- `--milestone Sprint 4` → milestone name = `Sprint 4`
-- `--sprint Sprint 4` → milestone name = `Sprint 4`
-- `--milestone Q2 Release` → milestone name = `Q2 Release`
-- `--milestone 12` → milestone name = `12`
-
-**Team mode:** If `--team` is present, enter team mode (Steps T1–T3 below) and skip Steps 2–6. `--team` is mutually exclusive with `--milestone`/`--sprint` and username arguments. If both are present, report the conflict and stop.
-
-**Personal mode** (no `--milestone` / `--sprint` / `--team` flag): determine:
-
-- **subject**: default `@me`. If the argument starts with `@` or is a plain word that is not a number, treat it as a GitHub username. Strip the leading `@` for `gh` commands that do not accept it (e.g. `gh pr list --author alice`); keep it for display.
-- **lookback**: default `7`. If the argument is a number (digits only), use it as the lookback window in days.
-
-No argument → subject = `@me`, lookback = `7`.
+Because it is read-only, the *shape* of its output does not matter: a differently-formatted-but-accurate summary is a fine result. Derive a clear, scannable layout yourself. What this skill pins down is the data to fetch, how to classify it, and the one piece of real opinion — the "what's next" ordering.
 
 ---
 
-## Step 2 — Fetch GitHub data (run all in parallel)
+## Step 1 — Determine mode
 
-Run these commands concurrently:
+Three mutually exclusive modes, selected from `$ARGUMENTS`:
 
-**Open PRs authored by subject:**
+- **Milestone mode** — `--milestone` or `--sprint` is present. Everything after the flag is the milestone name (a name or a number; trim outer whitespace, preserve internal spaces). Ignore other arguments. Run Steps M1–M2.
+- **Team mode** — `--team` is present. Run Steps T1–T2. `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username; if combined, report the conflict and stop.
+- **Personal mode** — no mode flag. **Subject** defaults to `@me`; a `@name` or a non-numeric word is a username (strip the leading `@` for `gh` flags that reject it, keep it for display). **Lookback** defaults to `7`; a bare number is the lookback in days.
+
+---
+
+## Step 2 — Fetch GitHub data (personal mode)
+
+Run these concurrently. If any `gh` command exits non-zero (including auth errors), report the message and stop — do not retry.
+
+**Open PRs authored by subject** — request enough fields to derive health (draft, CI, review decision, merge conflict) and staleness:
 ```bash
 gh pr list --author <subject> --state open \
   --json number,title,url,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
 ```
 
-**Recently merged PRs (last `<lookback>` days):**
+**Recently merged PRs**, filtered to those merged within `<lookback>` days:
 ```bash
 gh pr list --author <subject> --state merged --limit 20 \
   --json number,title,url,mergedAt,labels,baseRefName
 ```
-Filter the results to keep only entries where `mergedAt` is within the last `<lookback>` days.
 
 **Open issues assigned to subject:**
 ```bash
@@ -54,317 +48,103 @@ gh issue list --assignee <subject> --state open \
   --json number,title,url,labels,milestone,updatedAt
 ```
 
-**PRs requesting your review** (only when subject is `@me`):
+**PRs requesting your review** — only when subject is `@me`; skip for other users:
 ```bash
 gh pr list --search "review-requested:@me" --state open \
   --json number,title,url,author,updatedAt
 ```
-Skip this query when viewing another user's status.
 
-If any `gh` command exits with a non-zero status (including auth errors), report the error message and stop. Do not retry.
-
----
-
-## Step 3 — Fetch local git context
-
-Check if the current directory is inside a git repository:
-```bash
-git rev-parse --is-inside-work-tree
-```
-
-If yes, run:
+Also fetch local git context (skip and note if not in a git repo — `git rev-parse --is-inside-work-tree`):
 ```bash
 git log --oneline --since="<lookback> days ago"
 ```
 
-If not inside a git repo, skip this step and note it was skipped in the output.
+---
+
+## Step 3 — Classify and report (personal mode)
+
+Sort items into these buckets:
+
+- **In progress** — open PRs. Identify a linked issue from the PR body (`#N`, `closes #N`, `fixes #N`, `issue #N`) and cross-reference open issues.
+- **Done** — PRs merged within the lookback window.
+- **Up next** — open issues whose number is **not** referenced by any open PR body. (An issue linked from an open PR belongs under *In progress* with that PR, not here.)
+- **Needs your review** — the review-requested query (only when subject is `@me`).
+
+For each open PR, derive health from the JSON — draft state, CI status from `statusCheckRollup`, review state from `reviewDecision`, merge conflict from `mergeable`. Present each as a compact badge; omit a badge when it does not apply or is not configured.
+
+**Staleness:** flag any open PR or issue not updated within `14` days (a threshold of `0` disables staleness entirely). Note the last-updated date and age. This is a real config-driven rule — honor the threshold exactly.
+
+Report the buckets as a scannable summary: a heading naming the subject and lookback, a one-line count roll-up, then a section per non-empty bucket, then the local commits (or a note that git was skipped). Show labels/milestone only when present; dates as `YYYY-MM-DD`. If every GitHub bucket is empty, say so plainly for the subject and window.
+
+**Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Step 4 — Classify items
+## Step 4 — What's next (personal mode)
 
-Using the data from Steps 2 and 3, classify each item:
+After the summary, append **one** actionable suggestion. Gather the extra local state you need (current branch, `git status --porcelain`, latest tag via `git describe --tags --abbrev=0`, unreleased commit count via `git rev-list <tag>..HEAD --count`, and the current branch's PR review/check state via `gh pr view` — treat a non-zero exit as "no PR for this branch"). Skip git lookups when not in a repo.
 
-- **In progress** — open PRs. For each, attempt to identify a linked issue number from the PR body (look for `#N`, `closes #N`, `fixes #N`, `issue #N`). If found, cross-reference with open issues.
-- **Done** — merged PRs within the lookback window.
-- **Up next** — open issues that are NOT associated with any open PR (i.e. no open PR body references their issue number).
-- **Needs your review** — PRs from the review-requested query (only when subject is `@me`).
+Evaluate these conditions **in order** and use the **first** match. This ordering is the workflow's opinion about what the operator should do next — it is load-bearing, not formatting:
 
-An open issue that IS linked from an open PR body appears under "In progress" alongside that PR, not under "Up next".
+| Priority | Condition | Suggestion |
+|----------|-----------|------------|
+| 1 | On a `feature/*` branch with uncommitted changes | You have uncommitted changes on `<branch>`. When ready, run `/submit-for-review`. |
+| 2 | On a `feature/*` branch, open PR is `APPROVED` and all checks `COMPLETED` | PR #<number> is approved and checks pass. Consider running `/deploy`. |
+| 3 | On a `feature/*` branch with an open PR in any other state | PR #<number> (<title>) is open and awaiting review. |
+| 3.5 | Subject is `@me` and PRs request your review | Append to the current suggestion (or stand alone if nothing higher matched): You also have <N> PR(s) awaiting your review. |
+| 4 | On a `feature/*` branch, no open PR, clean tree | No open PR for `<branch>`. Run `/submit-for-review` to open one. |
+| 5 | On the integration branch with unreleased commits since the last tag | <N> commit(s) on `<branch>` since `<tag>`. Run `/deploy` when ready to release. |
+| 6 | No open PRs and no open issues assigned to subject | Nothing in progress. Run `/start` to begin new work. |
+| 7 | Open issues exist in "Up next" | Next up is #<number> (<title>). Run `/start <number>` to pick it up. |
 
-### 4a — Derive health badges
-
-For each open PR, derive the following badges:
-
-**Draft status:**
-- If `isDraft` is `true` → `[draft]`
-
-**CI check status** (from `statusCheckRollup`):
-- All checks have `status: COMPLETED` and `conclusion: SUCCESS` → `✅ checks passing`
-- Any check has `conclusion: FAILURE` → `❌ checks failing`
-- Checks are still running or have other states → `⏳ checks pending`
-- No checks configured → omit badge
-
-**Review decision** (from `reviewDecision`):
-- `APPROVED` → `✅ approved`
-- `CHANGES_REQUESTED` → `🔄 changes requested`
-- `REVIEW_REQUIRED` or empty → `⏳ awaiting review`
-
-**Merge conflict** (from `mergeable`):
-- `CONFLICTING` → `⚠️ conflicts`
-- `MERGEABLE` or `UNKNOWN` → omit badge
-
-### 4b — Flag stale items
-
-For each open PR and open issue, check `updatedAt`. If the item has not been updated within `14` days (default: 14; disabled when set to 0), flag it as stale. Record the last-updated date and the number of days since the last update.
-
-A stale item gets an inline `⚠️ stale (<N>d)` badge appended after any other badges.
+If none match, omit the "what's next" section. Omit it entirely in milestone mode.
 
 ---
 
-## Step 5 — Output the summary
+## Milestone mode (Steps M1–M2)
 
-Print a formatted summary. Use this structure:
-
-```
-## Status for <subject> — last <lookback> days
-
-<N> in progress · <N> done · <N> up next[ · <N> need your review]
-
-### In progress
-- #<number> <title> [<labels>] [<milestone>] [draft]
-  PR: <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>][ · <stale badge>]
-  Linked issue: #<number> (if found)
-
-### Done
-- #<number> <title> [<labels>] — merged <date>
-  PR: <url>
-
-### Needs your review
-- #<number> <title> (by @<author>)
-  PR: <url>
-
-### Up next
-- #<number> <title> [<labels>] [<milestone>][ · <stale badge>]
-  Issue: <url>
-
-### ⚠️ Stale
-- #<number> <title> — last updated <date> (<N> days ago)
-
----
-Local commits (current branch):
-<git log output, or "skipped — not in a git repo">
-```
-
-Rules:
-- **Summary counts line**: show immediately after the heading. Omit zero-count segments (e.g., if nothing is done, skip that segment). "need your review" only appears when subject is `@me` and the count is > 0.
-- **Health badges**: show on the second line of each "In progress" item, after the PR URL, separated by ` · `. Omit individual badges that don't apply (e.g., no conflict badge if mergeable).
-- **Draft badge**: show `[draft]` inline in the first line of draft PRs, before any other badges.
-- **Stale section**: a dedicated section at the bottom (before "Local commits") listing all stale items from any section, with their last-updated date and age. This gives a consolidated view. Individual items also get the inline `⚠️ stale (<N>d)` badge in their own sections.
-- **"Needs your review" section**: only shown when subject is `@me` and there are PRs requesting review. Placed between "Done" and "Up next".
-- Omit any section that has no items — do not show an empty heading.
-- Show labels only if present; show milestone only if present.
-- Dates use `YYYY-MM-DD` format.
-- If all GitHub sections are empty, print: `Nothing found for <subject> in the last <lookback> days.`
-
-Do not post, comment, write files, or take any action. Output only.
-
----
-
-## Step 6 — What's next
-
-After the status summary, append a single actionable suggestion based on local git state and the GitHub data already fetched.
-
-### 6a — Gather additional local state
-
-Run these commands (skip if not in a git repo):
-
-```bash
-git branch --show-current
-```
-
-```bash
-git status --porcelain
-```
-
-```bash
-git describe --tags --abbrev=0
-```
-
-```bash
-git rev-list <latest-tag>..HEAD --count
-```
-
-From the GitHub data fetched in Step 2, also check for the current branch's PR approval status:
-
-```bash
-gh pr view --json number,title,url,reviewDecision,statusCheckRollup \
-  --jq '{number,title,url,reviewDecision,checks: [.statusCheckRollup[]? | .status]}'
-```
-
-If `gh pr view` exits non-zero (no PR for current branch), note that there is no open PR.
-
-### 6b — Determine suggestion
-
-Evaluate the following conditions **in order**. Use the **first** match:
-
-| Priority | Condition | Output |
-|----------|-----------|--------|
-| 1 | On a `feature/*` branch with uncommitted changes (`git status --porcelain` is non-empty) | `What's next: You have uncommitted changes on \`<branch>\`. When ready, run \`/submit-for-review\`.` |
-| 2 | On a `feature/*` branch with an open PR that has `reviewDecision: APPROVED` and all status checks are `COMPLETED` | `What's next: PR #<number> is approved and checks pass. Consider running \`/deploy\`.` |
-| 3 | On a `feature/*` branch with an open PR (any other review/check state) | `What's next: PR #<number> (<title>) is open and awaiting review.` |
-| 3.5 | Subject is `@me` and there are PRs requesting your review (from Step 2 query) | Append to the current suggestion (or show standalone if no higher priority matched): `You also have <N> PR(s) awaiting your review.` |
-| 4 | On a `feature/*` branch with no open PR and clean working tree | `What's next: No open PR for \`<branch>\`. Run \`/submit-for-review\` to open one.` |
-| 5 | On the integration branch (`dev`, `develop`, or `main` when no integration branch exists) with unreleased commits (rev-list count > 0 since last tag) | `What's next: <N> commit(s) on \`<branch>\` since \`<tag>\`. Run \`/deploy\` when ready to release.` |
-| 6 | No open PRs, no open issues assigned to subject | `What's next: Nothing in progress. Run \`/start\` to begin new work.` |
-| 7 | Open issues exist in "Up next" | `What's next: Next up is #<number> (<title>). Run \`/start <number>\` to pick it up.` |
-
-If none of the above match, omit the "What's next" section entirely.
-
-### 6c — Format
-
-Print the suggestion after a horizontal rule, below the local commits section:
-
-```
----
-🧭 <suggestion text>
-```
-
-This section is omitted in milestone mode.
-
----
-
-## Milestone mode (Steps M1–M3)
-
-Only entered when `--milestone` or `--sprint` is detected in Step 1.
-
-### Step M1 — Fetch milestone issues
-
+### M1 — Fetch
 ```bash
 gh issue list --milestone "<name>" --state all --limit 200 \
   --json number,title,state,labels,assignees,url
-```
-
-If this command fails for any reason (milestone not found, auth error, etc.), report the error and stop.
-
-### Step M2 — Classify issues
-
-Fetch all open PRs to detect which issues are in progress (with health fields):
-
-```bash
 gh pr list --state open \
   --json number,title,body,baseRefName,reviewDecision,statusCheckRollup,mergeable,isDraft
 ```
+If the issue query fails (milestone not found, auth error), report and stop.
 
-Group issues into three buckets:
+### M2 — Classify and report
 
-- **Done** — `state: closed`
-- **In progress** — `state: open` AND the issue number appears in any open PR body (look for `#<number>`, `closes #<number>`, `fixes #<number>`, `related to #<number>`, `issue #<number>`)
-- **Not started** — `state: open` AND no open PR body references the issue number
+Group the milestone's issues into three buckets:
+- **Done** — `state: closed`.
+- **In progress** — open, and the issue number is referenced by some open PR body (`#N`, `closes #N`, `fixes #N`, `related to #N`, `issue #N`). This "referenced by an open PR" definition is the real rule — apply it exactly.
+- **Not started** — open, and no open PR references it.
 
-For in-progress issues, derive health badges from the linked PR using the same rules as Step 4a (check status, review decision, draft, conflict).
-
-### Step M3 — Output the summary
-
-```
-## Sprint: <name>
-
-<Y> of <total> issues closed · <Z> in progress · <W> not started
-
-### In progress (<Z>)
-- #<number> <title> [@<assignee>] [<milestone>][ [draft]]
-  <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>]
-
-### Not started (<W>)
-- #<number> <title> [@<assignee>]
-
-### Done (<Y>)
-- #<number> <title>
-```
-
-Rules:
-- Show "In progress" first, then "Not started", then "Done"
-- Show assignee only if present; omit if unassigned
-- Show URLs only for in-progress items; omit URLs for closed issues
-- Show health badges on in-progress items (same derivation as Step 4a)
-- If a section has no items, omit it entirely
-
-Do not post, comment, write files, or take any action. Output only.
+Derive health badges for in-progress issues from their linked PR (same fields as personal mode). Report as a scannable summary titled with the milestone name and a closed/in-progress/not-started roll-up. Show assignees and URLs where they add value; omit empty buckets. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Team mode (Steps T1–T3)
+## Team mode (Steps T1–T2)
 
-Only entered when `--team` is detected in Step 1.
-
-### Step T1 — Fetch all open work (run both in parallel)
-
+### T1 — Fetch (run both concurrently)
 ```bash
 gh pr list --state open --limit 100 \
   --json number,title,url,author,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
-```
-
-```bash
 gh issue list --state open --limit 200 \
   --json number,title,url,assignees,labels,milestone,updatedAt
 ```
+If either fails, report and stop.
 
-If either command fails, report the error and stop.
+### T2 — Group and report
 
-### Step T2 — Group and classify
-
-Group items by person:
-- PRs are grouped by `author.login`
-- Issues are grouped by assignee (first assignee if multiple). Issues with no assignee go into an "Unassigned" group.
-
-Within each person's group, classify items the same way as personal mode (Step 4):
-- **In progress** — open PRs (and linked issues)
-- **Up next** — open issues not linked from any open PR
-
-Derive health badges (Step 4a) and flag stale items (Step 4b) for all items.
-
-### Step T3 — Output the team summary
-
-```
-## Team status
-
-<N> open PRs · <N> open issues · <N> people
-
-### @<person> (<N> in progress, <N> up next)
-- #<number> <title> — PR <check badge> · <review badge>[ · <conflict badge>][ · <stale badge>][ [draft]]
-  <url>
-- #<number> <title> [up next][ · <stale badge>]
-
-### @<person> (<N> in progress, <N> up next)
-...
-
-### Unassigned (<N>)
-- #<number> <title>
-  <url>
-
-### ⚠️ Stale
-- #<number> <title> (@<person>) — last updated <date> (<N> days ago)
-```
-
-Rules:
-- Sort people alphabetically by username
-- Within each person, show in-progress items first, then up-next items
-- Show health badges on PR items (same format as personal mode)
-- Show `[draft]` on draft PRs
-- Tag up-next items with `[up next]` for visual distinction
-- "Unassigned" section appears at the bottom, only if there are unassigned issues
-- "Stale" section consolidates all stale items across all people
-- Omit any section or group with no items
-- No "What's next" section in team mode
-
-Do not post, comment, write files, or take any action. Output only.
+Group by person: PRs by `author.login`; issues by first assignee (unassigned issues into an "Unassigned" group). Within each person, classify as personal mode does — **in progress** (open PRs and their linked issues) and **up next** (open issues not referenced by any open PR) — and derive health badges plus staleness. Report per-person sections with in-progress items first, an "Unassigned" section if any, and a consolidated stale section. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
 ## Hard rules
 
-- Never write to GitHub (no comments, labels, issue updates, or PR changes).
-- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately.
-- Do not retry failed commands.
-- Strip the leading `@` from the subject when passing to `gh` flags that do not accept it.
-<!-- generated by CodeCannon/sync.py | skill: status | adapter: cursor | hash: 86d1632a | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+- Never write to GitHub (no comments, labels, issue updates, or PR changes) and never touch the working tree. Output only.
+- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately. Do not retry.
+- Strip the leading `@` from the subject when passing to `gh` flags that reject it.
+- `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username.
+- The `14` threshold is config-driven; `0` disables staleness. The "what's next" priority ordering is fixed — evaluate top to bottom, first match wins.
+<!-- generated by CodeCannon/sync.py | skill: status | adapter: cursor | hash: c0de60d9 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.gemini/skills/deploy/SKILL.md
+++ b/.gemini/skills/deploy/SKILL.md
@@ -9,25 +9,24 @@ description: Code Cannon: Bump the project version, create a GitHub Release, and
 
 ## What `/deploy` does
 
-`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote to production).
+`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote the deploy branch to production first).
+
+The branching mode changes the shape of the release: in **trunk mode** (`BRANCH_PROD` only) `/deploy` tags and releases the current branch directly; in **multi-branch mode** (`BRANCH_DEV` set, optionally with `BRANCH_TEST`) it first opens and merges a release PR from the deploy branch into production, and that merge is what closes the linked issues.
 
 ---
 
-## Step 1 — Verify branch
+## Step 1 — Verify branch and sync
 
-Run:
-```bash
-git branch --show-current
-```
+Run `git branch --show-current`. The **deploy branch** for this project is:
 
-Required branch: `dev` (two-branch mode).
+`dev` (two-branch mode).
 
-If not on the required branch, abort and say: "Switch to `<required-branch>` before running `/deploy`."
+If not on the deploy branch, abort: "Switch to `<deploy-branch>` before running `/deploy`."
 
-Sync to the remote before proceeding. The script below guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<base>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from CodeCannon's own merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they get silently discarded.
+Then sync it to the remote. The script guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<deploy-branch>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they are silently discarded.
 
 ```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py dev
+python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py <deploy-branch>
 ```
 
 If the script exits non-zero, stop and resolve the issue it reports before continuing.
@@ -36,87 +35,35 @@ If the script exits non-zero, stop and resolve the issue it reports before conti
 
 ## Step 2 — Check current state
 
-### Find the latest version tag
+Find the latest version tag (`git describe --tags --abbrev=0`; if none, note this is the first release) and read the current version with `cat VERSION`.
+
+Show the merge commits (and their PRs) since the last tag. The range depends on the mode:
 
 ```bash
-git describe --tags --abbrev=0
+git log main..<deploy-branch> --merges --pretty=format:"%s"
 ```
 
-If no tag exists, note this is the first release.
+Merge-commit subjects have the form `Merge pull request #N from branch/name` — parse the PR numbers, then retrieve each body with `gh pr view <N> --json number,title,body`.
 
-### Read current version
+From those PR bodies, compile the release's issue links:
 
-```bash
-cat VERSION
-```
+Keep closing keywords and context references **separate — do not merge them into one set**:
 
-### Show commits since last tag
+- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines so they can be reproduced verbatim in the release PR body.
+- **Reference set** — issues mentioned only via `Related to #N` or the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the human gate surfaces it so you can manually close any straggler that should have closed.
+- **PRs included** (number + title).
 
-If a previous tag exists, show what's on the branch since that tag:
+Also check for open unmerged PRs (`gh pr list --state open --json number,title,headRefName`).
 
-```bash
-git log main..dev --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
-
-Extract closing keywords **separately** from context references — do **not** merge them into a single set:
-
-- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These issues will auto-close when the release PR merges into `main`. Record, per constituent PR, the exact `Closes #N` lines it contained so they can be reproduced verbatim in the release PR body.
-- **Reference set** — issues mentioned only via `Related to #N`, or via the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the HUMAN GATE surfaces it so you can manually close any straggler that should have been a `Closes`.
-
-Compile:
-- List of PRs included (number + title)
-- Close set and reference set, kept distinct
-
-### Check for open unmerged PRs
-
-```bash
-gh pr list --state open --json number,title,headRefName
-```
-
-### Present the summary
-
-Tell the user:
-
-```
-Current version: X.Y.Z
-Latest tag: vX.Y.Z
-
-Commits/PRs since last tag:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
-
-Open PRs not yet merged:
-  #19 — Add dark mode (feature/dark-mode)
-
-Would you like to bump the version before deploying?
-  - **patch** → X.Y.C
-  - **minor** → X.B.0
-  - **major** → A.0.0
-  - **specific** → enter a version number
-  - **skip** → proceed to release with the latest existing tag
-```
-
-Wait for their response.
+Present a summary — current version, latest tag, the PRs/issues since that tag, any open PRs — and ask whether to bump the version before deploying (patch → X.Y.C, minor → X.B.0, major → A.0.0, a specific version, or skip to release the latest existing tag). Wait for their response.
 
 ---
 
 ## Step 3 — Version bump (if requested)
 
-If the user chose to skip, find the latest version tag in the branch history:
-```bash
-git describe --tags --abbrev=0
-```
+If the user chose **skip**, use the latest existing tag (`git describe --tags --abbrev=0`) as the release version. If none exists (first release), warn "No version tag found. You must bump the version before deploying." and return to the bump prompt.
 
-If no tag is found at all (first release), warn: "No version tag found. You must bump the version before deploying." Return to the version bump prompt. Otherwise, use the tag found as the release version.
-
-If the user chose a bump level, map their response to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it for the release step.
+If the user chose a bump level, map it to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it as `<new-version>`.
 
 | User says | `--bump-cmd` |
 |---|---|
@@ -131,59 +78,37 @@ python3 CodeCannon/skills/github-agile/scripts/bump-and-tag.py \
   --version-read-cmd "cat VERSION"
 ```
 
-If the script exits non-zero, stop and resolve the issue it reports before continuing. On success, the version printed on stdout is the new version — use it as `<new-version>` in subsequent steps.
+If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
 ---
 
 ## Step 4 — Compute release contents
 
-Determine the version tag (either from the bump just performed, or from the existing HEAD tag if the user skipped bumping).
+Determine the release version tag (from the bump just performed, or the existing HEAD tag if the user skipped). Find the previous tag for the changelog range: `git describe --abbrev=0 <version-tag>^`.
 
-Find the previous tag to determine the range:
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
+Reuse the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch as needed.
 
 ---
 
 ## Step 5 — HUMAN GATE
 
-Show the user the release summary. Example format:
+Show the release summary — the target version, the PRs included, and the issue links:
 
-```
-Ready to release vX.Y.Z to production.
+- Issues that will **close** on merge (the close set, reproduced verbatim from constituent PRs).
+- Issues **referenced but not closing** (the reference set — confirm none of these should actually close).
 
-PRs included:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
+Confirm the deploy branch has been tested:
+"Have you tested all of the above on preview? Type 'release' to confirm."
 
-Issues that will close on merge (Closes #N, reproduced verbatim from constituent PRs):
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
-
-Issues referenced but NOT closing (Related to #N / legacy Issue #N — confirm none of these should actually close):
-  #20 — Tighten error copy on the upload form
-
-Have you tested all of the above on preview? Type 'release' to confirm.
-```
-
-Wait for the user to type "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
+Wait for "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
 
 ---
 
-## Step 6 — Create PR: `dev` → `main`
+## Step 6 — Promote: `<deploy-branch>` → `main`
 
-First, create a temp directory for this invocation:
+Create a temp directory for this invocation (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`) and note the returned path — use it for all temp files here.
 
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
+Use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
 
 ```markdown
 Release vX.Y.Z
@@ -198,53 +123,31 @@ Closes #15
 Related to #20
 ```
 
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
+Reproduce **every** `Closes #N` line from the close set — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear without triggering an auto-close; if the reference set is empty, omit the `Related to` lines entirely.
 
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
+Create the PR (do NOT use `--body`, `--body-file -`, or heredocs), with `--head` set to the deploy branch:
 
 ```bash
-gh pr create --base main --head dev \
+gh pr create --base main --head <deploy-branch> \
   --title "Release vX.Y.Z" \
   --body-file <tmpdir>/release_pr_body.md
 ```
 
-Note the PR number from the output.
+> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close. The `Closes #N` lines auto-close the linked issues because this PR merges into `main` (the default branch).
 
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `main` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
+Then merge. Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge <pr-number> --merge` directly.
 
 ---
 
-## Step 7 — Merge
+## Step 7 — Create the GitHub Release
 
-Do NOT use `make merge` — it refuses PRs targeting `main`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
+**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action; the confirmation from Step 5 authorized the promotion, but the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
 
 > Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
 
 Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
 
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
+The version tag and PR/issue list are already known; the previous tag comes from Step 4 (if there is no previous tag, omit the "Full changelog" line). Create a temp directory if you haven't already (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`), then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
 
 ```markdown
 ## Changes
@@ -255,7 +158,7 @@ Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (sam
 **Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
 ```
 
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
+Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`; if a PR had no linked issue, use just the PR title. Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
 
 ```bash
 gh release create <version-tag> \
@@ -263,15 +166,11 @@ gh release create <version-tag> \
   --notes-file <tmpdir>/release_notes.md
 ```
 
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
+Note the release URL from the output.
 
 ---
 
-## Step 9 — Report
+## Step 8 — Report
 
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
-<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: gemini | hash: 4c21b5df | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+Tell the user: "Released vX.Y.Z. Linked issues are closed. GitHub Release vX.Y.Z created at `<url>`. Run `make deploy-prod` to ship to production."
+<!-- generated by CodeCannon/sync.py | skill: deploy | adapter: gemini | hash: 904fbcdf | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.gemini/skills/start/SKILL.md
+++ b/.gemini/skills/start/SKILL.md
@@ -27,12 +27,10 @@ Otherwise → go to **Case A: New work**.
 
 > **Execution order:** Resolve labels and milestones **now**, before entering Case A Step 1. If milestone auto-detection requires a user prompt (2+ open milestones), that prompt happens here — not later during issue creation. By the time you reach Step 2's human gate, all metadata must already be resolved so that Step 3 can proceed without re-prompting.
 
-The argument string may contain optional inline flags after the description. Parse as follows:
+The description may be followed by optional flags — `--label`/`-l` and `--milestone`/`-m`, in any order. Separate the description from the flags yourself; the flags carry these meanings:
 
-1. **Identify flags** — scan for the first token that starts with `--label`, `-l`, `--milestone`, or `-m`. Everything before it is the **description**. Everything from the first flag onward is **flags**.
-2. **`--label <value>` / `-l <value>`** — comma-separated label string (e.g. `bug` or `enhancement,ux`). If provided, it **bypasses label auto-selection entirely** for this invocation — use the value verbatim. Labels containing spaces must be quoted (e.g. `--label "good first issue"`).
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). Pass the value as-is; GitHub accepts both names and numbers.
-4. **Flags may appear in any order** after the description.
+- **`--label <value>` / `-l <value>`** — a comma-separated label string used **verbatim**, bypassing label auto-selection entirely for this invocation. Quote values containing spaces (e.g. `--label "good first issue"`).
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number (GitHub accepts both names and numbers).
 
 **Label resolution (three-tier, Case A only):**
 
@@ -56,14 +54,6 @@ After parsing flags, determine the active milestone in this order:
    - **0 results** → no milestone; proceed without `--milestone`.
    - **1 result** → use its title silently. Inform the user inline: `(milestone: <title>)`.
    - **2+ results** → show the numbered list, ask once: **"Multiple open milestones — which should this issue go under? (enter a number or title, or 'none')"**. Accept milestone number, title, or "none"/"skip". Wait for response before continuing.
-
-**Examples:**
-
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
 
 > Replace vs append: flags **replace** auto-selection entirely, they do not append. This avoids silent label duplication and milestone conflicts.
 
@@ -102,7 +92,7 @@ If on any other branch → proceed to Case A or Case B as determined by the `$AR
 
 ### Step 1 — Investigate
 
-Read the relevant code. Propose a concrete implementation approach. Be specific about which files change and how.
+Read the relevant code using your harness's native file-reading and search tools (read, grep/glob, and the like) rather than shell pipelines — hand-rolled `find … | xargs`, `grep ; awk`, or redirection shapes trigger permission prompts that cannot be permanently allowed. Then propose a concrete implementation approach, specific about which files change and how.
 
 ### Step 2 — HUMAN GATE
 
@@ -222,7 +212,14 @@ Show the user: `On branch feature/<name>`
 
 ### Step 5 — Write the code
 
-Now write the code. Do NOT commit anything.
+Write the code using your harness's native editing tools. Do NOT commit anything.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -317,7 +314,14 @@ git branch --show-current
 
 ### Step 5 — Write the code
 
-Continue from where work left off. Do NOT commit.
+Continue from where work left off, using your harness's native editing tools. Do NOT commit.
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+make test
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -336,4 +340,4 @@ When done, say: **"When you've verified locally, reply `yes` to submit, or say w
 - The issue is assigned to `@me` at creation. If you are creating a ticket on someone else's behalf, remove the assignee after creation with `gh issue edit <number> --remove-assignee @me`.
 - Apply resolved labels and milestone to every new issue. Label resolution order: per-invocation flag → pool selection from `bug, documentation, enhancement, chore` → omit `--label` entirely. Never apply a label outside `bug, documentation, enhancement, chore`.
 - Milestone resolution order: per-invocation flag → auto-detected from GitHub open milestones. Never prompt for a milestone more than once per invocation.
-<!-- generated by CodeCannon/sync.py | skill: start | adapter: gemini | hash: 0af62e25 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+<!-- generated by CodeCannon/sync.py | skill: start | adapter: gemini | hash: 21fde40c | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/.gemini/skills/status/SKILL.md
+++ b/.gemini/skills/status/SKILL.md
@@ -7,45 +7,39 @@ description: Code Cannon: Summarize in-progress and recently completed work from
 
 ---
 
-## Step 1 — Parse arguments
+## What `/status` does
 
-First, check whether `$ARGUMENTS` contains `--milestone`, `--sprint`, or `--team`.
+`/status` prints a read-only, standup-ready snapshot of in-progress and recently completed work, then a single "what's next" suggestion. It never writes to GitHub or the working tree — it only reads and reports.
 
-**Milestone mode:** If `--milestone` or `--sprint` is present, extract everything after the flag as the milestone name (trim leading/trailing whitespace; preserve internal spaces). Ignore any other arguments. Enter milestone mode (Steps M1–M3 below) and skip Steps 2–6.
-
-Examples:
-- `--milestone Sprint 4` → milestone name = `Sprint 4`
-- `--sprint Sprint 4` → milestone name = `Sprint 4`
-- `--milestone Q2 Release` → milestone name = `Q2 Release`
-- `--milestone 12` → milestone name = `12`
-
-**Team mode:** If `--team` is present, enter team mode (Steps T1–T3 below) and skip Steps 2–6. `--team` is mutually exclusive with `--milestone`/`--sprint` and username arguments. If both are present, report the conflict and stop.
-
-**Personal mode** (no `--milestone` / `--sprint` / `--team` flag): determine:
-
-- **subject**: default `@me`. If the argument starts with `@` or is a plain word that is not a number, treat it as a GitHub username. Strip the leading `@` for `gh` commands that do not accept it (e.g. `gh pr list --author alice`); keep it for display.
-- **lookback**: default `7`. If the argument is a number (digits only), use it as the lookback window in days.
-
-No argument → subject = `@me`, lookback = `7`.
+Because it is read-only, the *shape* of its output does not matter: a differently-formatted-but-accurate summary is a fine result. Derive a clear, scannable layout yourself. What this skill pins down is the data to fetch, how to classify it, and the one piece of real opinion — the "what's next" ordering.
 
 ---
 
-## Step 2 — Fetch GitHub data (run all in parallel)
+## Step 1 — Determine mode
 
-Run these commands concurrently:
+Three mutually exclusive modes, selected from `$ARGUMENTS`:
 
-**Open PRs authored by subject:**
+- **Milestone mode** — `--milestone` or `--sprint` is present. Everything after the flag is the milestone name (a name or a number; trim outer whitespace, preserve internal spaces). Ignore other arguments. Run Steps M1–M2.
+- **Team mode** — `--team` is present. Run Steps T1–T2. `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username; if combined, report the conflict and stop.
+- **Personal mode** — no mode flag. **Subject** defaults to `@me`; a `@name` or a non-numeric word is a username (strip the leading `@` for `gh` flags that reject it, keep it for display). **Lookback** defaults to `7`; a bare number is the lookback in days.
+
+---
+
+## Step 2 — Fetch GitHub data (personal mode)
+
+Run these concurrently. If any `gh` command exits non-zero (including auth errors), report the message and stop — do not retry.
+
+**Open PRs authored by subject** — request enough fields to derive health (draft, CI, review decision, merge conflict) and staleness:
 ```bash
 gh pr list --author <subject> --state open \
   --json number,title,url,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
 ```
 
-**Recently merged PRs (last `<lookback>` days):**
+**Recently merged PRs**, filtered to those merged within `<lookback>` days:
 ```bash
 gh pr list --author <subject> --state merged --limit 20 \
   --json number,title,url,mergedAt,labels,baseRefName
 ```
-Filter the results to keep only entries where `mergedAt` is within the last `<lookback>` days.
 
 **Open issues assigned to subject:**
 ```bash
@@ -53,317 +47,103 @@ gh issue list --assignee <subject> --state open \
   --json number,title,url,labels,milestone,updatedAt
 ```
 
-**PRs requesting your review** (only when subject is `@me`):
+**PRs requesting your review** — only when subject is `@me`; skip for other users:
 ```bash
 gh pr list --search "review-requested:@me" --state open \
   --json number,title,url,author,updatedAt
 ```
-Skip this query when viewing another user's status.
 
-If any `gh` command exits with a non-zero status (including auth errors), report the error message and stop. Do not retry.
-
----
-
-## Step 3 — Fetch local git context
-
-Check if the current directory is inside a git repository:
-```bash
-git rev-parse --is-inside-work-tree
-```
-
-If yes, run:
+Also fetch local git context (skip and note if not in a git repo — `git rev-parse --is-inside-work-tree`):
 ```bash
 git log --oneline --since="<lookback> days ago"
 ```
 
-If not inside a git repo, skip this step and note it was skipped in the output.
+---
+
+## Step 3 — Classify and report (personal mode)
+
+Sort items into these buckets:
+
+- **In progress** — open PRs. Identify a linked issue from the PR body (`#N`, `closes #N`, `fixes #N`, `issue #N`) and cross-reference open issues.
+- **Done** — PRs merged within the lookback window.
+- **Up next** — open issues whose number is **not** referenced by any open PR body. (An issue linked from an open PR belongs under *In progress* with that PR, not here.)
+- **Needs your review** — the review-requested query (only when subject is `@me`).
+
+For each open PR, derive health from the JSON — draft state, CI status from `statusCheckRollup`, review state from `reviewDecision`, merge conflict from `mergeable`. Present each as a compact badge; omit a badge when it does not apply or is not configured.
+
+**Staleness:** flag any open PR or issue not updated within `14` days (a threshold of `0` disables staleness entirely). Note the last-updated date and age. This is a real config-driven rule — honor the threshold exactly.
+
+Report the buckets as a scannable summary: a heading naming the subject and lookback, a one-line count roll-up, then a section per non-empty bucket, then the local commits (or a note that git was skipped). Show labels/milestone only when present; dates as `YYYY-MM-DD`. If every GitHub bucket is empty, say so plainly for the subject and window.
+
+**Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Step 4 — Classify items
+## Step 4 — What's next (personal mode)
 
-Using the data from Steps 2 and 3, classify each item:
+After the summary, append **one** actionable suggestion. Gather the extra local state you need (current branch, `git status --porcelain`, latest tag via `git describe --tags --abbrev=0`, unreleased commit count via `git rev-list <tag>..HEAD --count`, and the current branch's PR review/check state via `gh pr view` — treat a non-zero exit as "no PR for this branch"). Skip git lookups when not in a repo.
 
-- **In progress** — open PRs. For each, attempt to identify a linked issue number from the PR body (look for `#N`, `closes #N`, `fixes #N`, `issue #N`). If found, cross-reference with open issues.
-- **Done** — merged PRs within the lookback window.
-- **Up next** — open issues that are NOT associated with any open PR (i.e. no open PR body references their issue number).
-- **Needs your review** — PRs from the review-requested query (only when subject is `@me`).
+Evaluate these conditions **in order** and use the **first** match. This ordering is the workflow's opinion about what the operator should do next — it is load-bearing, not formatting:
 
-An open issue that IS linked from an open PR body appears under "In progress" alongside that PR, not under "Up next".
+| Priority | Condition | Suggestion |
+|----------|-----------|------------|
+| 1 | On a `feature/*` branch with uncommitted changes | You have uncommitted changes on `<branch>`. When ready, run `/submit-for-review`. |
+| 2 | On a `feature/*` branch, open PR is `APPROVED` and all checks `COMPLETED` | PR #<number> is approved and checks pass. Consider running `/deploy`. |
+| 3 | On a `feature/*` branch with an open PR in any other state | PR #<number> (<title>) is open and awaiting review. |
+| 3.5 | Subject is `@me` and PRs request your review | Append to the current suggestion (or stand alone if nothing higher matched): You also have <N> PR(s) awaiting your review. |
+| 4 | On a `feature/*` branch, no open PR, clean tree | No open PR for `<branch>`. Run `/submit-for-review` to open one. |
+| 5 | On the integration branch with unreleased commits since the last tag | <N> commit(s) on `<branch>` since `<tag>`. Run `/deploy` when ready to release. |
+| 6 | No open PRs and no open issues assigned to subject | Nothing in progress. Run `/start` to begin new work. |
+| 7 | Open issues exist in "Up next" | Next up is #<number> (<title>). Run `/start <number>` to pick it up. |
 
-### 4a — Derive health badges
-
-For each open PR, derive the following badges:
-
-**Draft status:**
-- If `isDraft` is `true` → `[draft]`
-
-**CI check status** (from `statusCheckRollup`):
-- All checks have `status: COMPLETED` and `conclusion: SUCCESS` → `✅ checks passing`
-- Any check has `conclusion: FAILURE` → `❌ checks failing`
-- Checks are still running or have other states → `⏳ checks pending`
-- No checks configured → omit badge
-
-**Review decision** (from `reviewDecision`):
-- `APPROVED` → `✅ approved`
-- `CHANGES_REQUESTED` → `🔄 changes requested`
-- `REVIEW_REQUIRED` or empty → `⏳ awaiting review`
-
-**Merge conflict** (from `mergeable`):
-- `CONFLICTING` → `⚠️ conflicts`
-- `MERGEABLE` or `UNKNOWN` → omit badge
-
-### 4b — Flag stale items
-
-For each open PR and open issue, check `updatedAt`. If the item has not been updated within `14` days (default: 14; disabled when set to 0), flag it as stale. Record the last-updated date and the number of days since the last update.
-
-A stale item gets an inline `⚠️ stale (<N>d)` badge appended after any other badges.
+If none match, omit the "what's next" section. Omit it entirely in milestone mode.
 
 ---
 
-## Step 5 — Output the summary
+## Milestone mode (Steps M1–M2)
 
-Print a formatted summary. Use this structure:
-
-```
-## Status for <subject> — last <lookback> days
-
-<N> in progress · <N> done · <N> up next[ · <N> need your review]
-
-### In progress
-- #<number> <title> [<labels>] [<milestone>] [draft]
-  PR: <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>][ · <stale badge>]
-  Linked issue: #<number> (if found)
-
-### Done
-- #<number> <title> [<labels>] — merged <date>
-  PR: <url>
-
-### Needs your review
-- #<number> <title> (by @<author>)
-  PR: <url>
-
-### Up next
-- #<number> <title> [<labels>] [<milestone>][ · <stale badge>]
-  Issue: <url>
-
-### ⚠️ Stale
-- #<number> <title> — last updated <date> (<N> days ago)
-
----
-Local commits (current branch):
-<git log output, or "skipped — not in a git repo">
-```
-
-Rules:
-- **Summary counts line**: show immediately after the heading. Omit zero-count segments (e.g., if nothing is done, skip that segment). "need your review" only appears when subject is `@me` and the count is > 0.
-- **Health badges**: show on the second line of each "In progress" item, after the PR URL, separated by ` · `. Omit individual badges that don't apply (e.g., no conflict badge if mergeable).
-- **Draft badge**: show `[draft]` inline in the first line of draft PRs, before any other badges.
-- **Stale section**: a dedicated section at the bottom (before "Local commits") listing all stale items from any section, with their last-updated date and age. This gives a consolidated view. Individual items also get the inline `⚠️ stale (<N>d)` badge in their own sections.
-- **"Needs your review" section**: only shown when subject is `@me` and there are PRs requesting review. Placed between "Done" and "Up next".
-- Omit any section that has no items — do not show an empty heading.
-- Show labels only if present; show milestone only if present.
-- Dates use `YYYY-MM-DD` format.
-- If all GitHub sections are empty, print: `Nothing found for <subject> in the last <lookback> days.`
-
-Do not post, comment, write files, or take any action. Output only.
-
----
-
-## Step 6 — What's next
-
-After the status summary, append a single actionable suggestion based on local git state and the GitHub data already fetched.
-
-### 6a — Gather additional local state
-
-Run these commands (skip if not in a git repo):
-
-```bash
-git branch --show-current
-```
-
-```bash
-git status --porcelain
-```
-
-```bash
-git describe --tags --abbrev=0
-```
-
-```bash
-git rev-list <latest-tag>..HEAD --count
-```
-
-From the GitHub data fetched in Step 2, also check for the current branch's PR approval status:
-
-```bash
-gh pr view --json number,title,url,reviewDecision,statusCheckRollup \
-  --jq '{number,title,url,reviewDecision,checks: [.statusCheckRollup[]? | .status]}'
-```
-
-If `gh pr view` exits non-zero (no PR for current branch), note that there is no open PR.
-
-### 6b — Determine suggestion
-
-Evaluate the following conditions **in order**. Use the **first** match:
-
-| Priority | Condition | Output |
-|----------|-----------|--------|
-| 1 | On a `feature/*` branch with uncommitted changes (`git status --porcelain` is non-empty) | `What's next: You have uncommitted changes on \`<branch>\`. When ready, run \`/submit-for-review\`.` |
-| 2 | On a `feature/*` branch with an open PR that has `reviewDecision: APPROVED` and all status checks are `COMPLETED` | `What's next: PR #<number> is approved and checks pass. Consider running \`/deploy\`.` |
-| 3 | On a `feature/*` branch with an open PR (any other review/check state) | `What's next: PR #<number> (<title>) is open and awaiting review.` |
-| 3.5 | Subject is `@me` and there are PRs requesting your review (from Step 2 query) | Append to the current suggestion (or show standalone if no higher priority matched): `You also have <N> PR(s) awaiting your review.` |
-| 4 | On a `feature/*` branch with no open PR and clean working tree | `What's next: No open PR for \`<branch>\`. Run \`/submit-for-review\` to open one.` |
-| 5 | On the integration branch (`dev`, `develop`, or `main` when no integration branch exists) with unreleased commits (rev-list count > 0 since last tag) | `What's next: <N> commit(s) on \`<branch>\` since \`<tag>\`. Run \`/deploy\` when ready to release.` |
-| 6 | No open PRs, no open issues assigned to subject | `What's next: Nothing in progress. Run \`/start\` to begin new work.` |
-| 7 | Open issues exist in "Up next" | `What's next: Next up is #<number> (<title>). Run \`/start <number>\` to pick it up.` |
-
-If none of the above match, omit the "What's next" section entirely.
-
-### 6c — Format
-
-Print the suggestion after a horizontal rule, below the local commits section:
-
-```
----
-🧭 <suggestion text>
-```
-
-This section is omitted in milestone mode.
-
----
-
-## Milestone mode (Steps M1–M3)
-
-Only entered when `--milestone` or `--sprint` is detected in Step 1.
-
-### Step M1 — Fetch milestone issues
-
+### M1 — Fetch
 ```bash
 gh issue list --milestone "<name>" --state all --limit 200 \
   --json number,title,state,labels,assignees,url
-```
-
-If this command fails for any reason (milestone not found, auth error, etc.), report the error and stop.
-
-### Step M2 — Classify issues
-
-Fetch all open PRs to detect which issues are in progress (with health fields):
-
-```bash
 gh pr list --state open \
   --json number,title,body,baseRefName,reviewDecision,statusCheckRollup,mergeable,isDraft
 ```
+If the issue query fails (milestone not found, auth error), report and stop.
 
-Group issues into three buckets:
+### M2 — Classify and report
 
-- **Done** — `state: closed`
-- **In progress** — `state: open` AND the issue number appears in any open PR body (look for `#<number>`, `closes #<number>`, `fixes #<number>`, `related to #<number>`, `issue #<number>`)
-- **Not started** — `state: open` AND no open PR body references the issue number
+Group the milestone's issues into three buckets:
+- **Done** — `state: closed`.
+- **In progress** — open, and the issue number is referenced by some open PR body (`#N`, `closes #N`, `fixes #N`, `related to #N`, `issue #N`). This "referenced by an open PR" definition is the real rule — apply it exactly.
+- **Not started** — open, and no open PR references it.
 
-For in-progress issues, derive health badges from the linked PR using the same rules as Step 4a (check status, review decision, draft, conflict).
-
-### Step M3 — Output the summary
-
-```
-## Sprint: <name>
-
-<Y> of <total> issues closed · <Z> in progress · <W> not started
-
-### In progress (<Z>)
-- #<number> <title> [@<assignee>] [<milestone>][ [draft]]
-  <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>]
-
-### Not started (<W>)
-- #<number> <title> [@<assignee>]
-
-### Done (<Y>)
-- #<number> <title>
-```
-
-Rules:
-- Show "In progress" first, then "Not started", then "Done"
-- Show assignee only if present; omit if unassigned
-- Show URLs only for in-progress items; omit URLs for closed issues
-- Show health badges on in-progress items (same derivation as Step 4a)
-- If a section has no items, omit it entirely
-
-Do not post, comment, write files, or take any action. Output only.
+Derive health badges for in-progress issues from their linked PR (same fields as personal mode). Report as a scannable summary titled with the milestone name and a closed/in-progress/not-started roll-up. Show assignees and URLs where they add value; omit empty buckets. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Team mode (Steps T1–T3)
+## Team mode (Steps T1–T2)
 
-Only entered when `--team` is detected in Step 1.
-
-### Step T1 — Fetch all open work (run both in parallel)
-
+### T1 — Fetch (run both concurrently)
 ```bash
 gh pr list --state open --limit 100 \
   --json number,title,url,author,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
-```
-
-```bash
 gh issue list --state open --limit 200 \
   --json number,title,url,assignees,labels,milestone,updatedAt
 ```
+If either fails, report and stop.
 
-If either command fails, report the error and stop.
+### T2 — Group and report
 
-### Step T2 — Group and classify
-
-Group items by person:
-- PRs are grouped by `author.login`
-- Issues are grouped by assignee (first assignee if multiple). Issues with no assignee go into an "Unassigned" group.
-
-Within each person's group, classify items the same way as personal mode (Step 4):
-- **In progress** — open PRs (and linked issues)
-- **Up next** — open issues not linked from any open PR
-
-Derive health badges (Step 4a) and flag stale items (Step 4b) for all items.
-
-### Step T3 — Output the team summary
-
-```
-## Team status
-
-<N> open PRs · <N> open issues · <N> people
-
-### @<person> (<N> in progress, <N> up next)
-- #<number> <title> — PR <check badge> · <review badge>[ · <conflict badge>][ · <stale badge>][ [draft]]
-  <url>
-- #<number> <title> [up next][ · <stale badge>]
-
-### @<person> (<N> in progress, <N> up next)
-...
-
-### Unassigned (<N>)
-- #<number> <title>
-  <url>
-
-### ⚠️ Stale
-- #<number> <title> (@<person>) — last updated <date> (<N> days ago)
-```
-
-Rules:
-- Sort people alphabetically by username
-- Within each person, show in-progress items first, then up-next items
-- Show health badges on PR items (same format as personal mode)
-- Show `[draft]` on draft PRs
-- Tag up-next items with `[up next]` for visual distinction
-- "Unassigned" section appears at the bottom, only if there are unassigned issues
-- "Stale" section consolidates all stale items across all people
-- Omit any section or group with no items
-- No "What's next" section in team mode
-
-Do not post, comment, write files, or take any action. Output only.
+Group by person: PRs by `author.login`; issues by first assignee (unassigned issues into an "Unassigned" group). Within each person, classify as personal mode does — **in progress** (open PRs and their linked issues) and **up next** (open issues not referenced by any open PR) — and derive health badges plus staleness. Report per-person sections with in-progress items first, an "Unassigned" section if any, and a consolidated stale section. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
 ## Hard rules
 
-- Never write to GitHub (no comments, labels, issue updates, or PR changes).
-- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately.
-- Do not retry failed commands.
-- Strip the leading `@` from the subject when passing to `gh` flags that do not accept it.
-<!-- generated by CodeCannon/sync.py | skill: status | adapter: gemini | hash: 11176f8f | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->
+- Never write to GitHub (no comments, labels, issue updates, or PR changes) and never touch the working tree. Output only.
+- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately. Do not retry.
+- Strip the leading `@` from the subject when passing to `gh` flags that reject it.
+- `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username.
+- The `14` threshold is config-driven; `0` disables staleness. The "what's next" priority ordering is fixed — evaluate top to bottom, first match wins.
+<!-- generated by CodeCannon/sync.py | skill: status | adapter: gemini | hash: 203ddda9 | DO NOT EDIT — run CodeCannon/sync.py to regenerate -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,26 @@ ROADMAP.md               Future ideas and planned work
 .codecannon.yaml         Project config (also listed under Configuration)
 ```
 
+## Skill design philosophy
+
+CodeCannon's skills were first written for a generation of models that needed to be told not just *what* outcome to produce but *how* to produce it — how to parse an argument string, what date format to use, which emoji maps to which CI state. Capable agents do all of that well unaided. Procedural over-specification no longer buys reliability; it burns context, crowds out the instructions that matter, and blocks a capable agent from doing something smarter than the author imagined.
+
+Every instruction in a skill must pass one test:
+
+> **Prune where model variance produces a different-but-fine result. Keep where model variance produces a wrong result.**
+
+- **Prune side** — report formatting, argument tokenizing, investigation method, output templates, badge-to-emoji mappings. A differently-shaped-but-correct result is harmless, so hand the agent the intent and the inputs, not the procedure.
+- **Keep side** — ordering guarantees, human approval gates (and their exact wording), platform behaviour the model cannot derive, review policy, and the prompt-avoidance instructions (`--body-file` / no-heredoc / no-`$(cat)`). Variance in any of these is a defect, not a style difference.
+
+Two categories look like removable noise when read quickly but are load-bearing — never weaken them:
+
+- **Prompt-avoidance guidance.** The `--body-file` and no-heredoc blocks exist *because* embedding markdown in a shell command triggers permission prompts that cannot be permanently allowed. State the rule once here and point at it; do not restate it per skill and do not soften it.
+- **Platform-behaviour notes.** Facts like "unqualified `#N` populates `closingIssuesReferences`", "`Closes` is inert on non-default-branch merges", and "`gh issue develop --base` reads from the API, not local working state" are knowledge a model has no way to derive. Keep them verbatim.
+
+Calibrate the prune against the **weakest** supported harness and model size, not the strongest. Skills ship to several adapters and a range of model sizes; trusting the agent as far as the best available model would under-serve everyone else. The cost of variance decides where the line sits — not the capability of the strongest model.
+
+`story.md` is the reference shape: overwhelmingly *what* rather than *how*, with business rules collected under a `## Hard rules` section at the end and procedure written only where sequencing genuinely matters. Converge older skills toward it.
+
 ## Skill anatomy
 
 Each skill in `skills/` follows this structure:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Plus `/qa` for structured QA workflows and `/setup` for guided onboarding.
 
 **Configure, don't fork.** Skills use `{{PLACEHOLDER}}` tokens. Your `.codecannon.yaml` fills them in. When upstream improves, pull the submodule and re-sync.
 
+## What makes a good skill
+
+Anyone can write a skill. What separates a good one from a bad one is not how thoroughly it dictates procedure — it is **token economy**, **respect for the developer's attention**, and knowing **which decisions belong to the workflow versus which belong to the agent**.
+
+Early skills, written for weaker models, spelled out not just *what* outcome to produce but *how* to produce it: how to parse an argument string, what date format to use, which emoji maps to which CI state. Capable agents do all of that unaided. Over-specification looks rigorous and is actually fragile — it burns context on instructions the model does not need, it breaks whenever the underlying tool changes, and it stops a capable agent from doing something smarter than the author imagined.
+
+Code Cannon holds every instruction to one test:
+
+> **Prune where model variance produces a different-but-fine result. Keep where model variance produces a wrong result.**
+
+Report formatting, argument parsing, and investigation method fall on the *prune* side — a differently-shaped-but-correct result is harmless. Ordering guarantees, human approval gates, platform behaviour a model cannot derive, and review policy fall on the *keep* side — variance there is a defect. Pulling back is **not** the same as removing constraints: everything that encodes a real rule stays exactly as it is. The skill authoring guidance in [`AGENTS.md`](AGENTS.md#skill-design-philosophy) applies this test in full, including the two categories — prompt-avoidance instructions and platform-behaviour notes — that read as noise but are load-bearing, and the reminder to calibrate against the weakest supported model, not the strongest.
+
 ## Quick start
 
 Requires Python 3.8+ (stdlib only — no pip install needed).

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -108,6 +108,12 @@ placeholders:
     category: workflow
     used_in: [submit-for-review]
 
+  TEST_CMD:
+    description: "Command that runs the project's test suite during development, so /start's coding loop can point at it instead of the agent hand-rolling a test invocation. Optional and opt-in: empty (the default) means no separate test target exists, and /start degrades silently rather than inventing one — verification then rests on CHECK_CMD at the /submit-for-review gate. Set it (e.g. 'make test', 'npm test', 'pytest') only when the project has a real test command."
+    default: ""
+    category: workflow
+    used_in: [start]
+
   MERGE_CMD:
     description: "Merge the current feature PR into the integration branch"
     default: "make merge"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -28,6 +28,7 @@ See [branching models](branching.md) for how these values change skill behavior.
 | Key | Default | Used in | Description |
 |---|---|---|---|
 | `CHECK_CMD` | `make check` | submit-for-review | Type-check / lint gate that must pass before shipping. |
+| `TEST_CMD` | *(empty)* | start | Optional test-suite command `/start`'s coding loop points at instead of hand-rolling one. Empty (the default) means no separate test target — `/start` degrades silently and verification rests on `CHECK_CMD`. |
 | `DEV_CMD` | `make dev` | start | Start the local development server. Suggested to user after `/start` writes code. |
 | `ABANDON_CMD` | `make abandon` | start | Discard all changes and delete the current feature branch. |
 | `MERGE_CMD` | `make merge` | submit-for-review, deploy | Merge the current feature PR into the integration branch. |

--- a/skills/github-agile/deploy.md
+++ b/skills/github-agile/deploy.md
@@ -7,50 +7,35 @@ args: none
 
 ## What `/deploy` does
 
-`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote to production).
+`/deploy` is the final step in the workflow. It combines version bumping and release creation into a single command: check state, optionally bump the version, then create a GitHub Release (and in multi-branch mode, promote the deploy branch to production first).
+
+The branching mode changes the shape of the release: in **trunk mode** (`BRANCH_PROD` only) `/deploy` tags and releases the current branch directly; in **multi-branch mode** (`BRANCH_DEV` set, optionally with `BRANCH_TEST`) it first opens and merges a release PR from the deploy branch into production, and that merge is what closes the linked issues.
 
 ---
 
-## Step 1 — Verify branch
+## Step 1 — Verify branch and sync
 
-Run:
-```bash
-git branch --show-current
-```
+Run `git branch --show-current`. The **deploy branch** for this project is:
 
 {{#if BRANCH_TEST}}
-Required branch: `{{BRANCH_TEST}}` (three-branch mode).
+`{{BRANCH_TEST}}` (three-branch mode).
 {{/if}}
 {{#if !BRANCH_TEST}}
 {{#if BRANCH_DEV}}
-Required branch: `{{BRANCH_DEV}}` (two-branch mode).
+`{{BRANCH_DEV}}` (two-branch mode).
 {{/if}}
 {{#if !BRANCH_DEV}}
-Required branch: `{{BRANCH_PROD}}` (trunk mode).
+`{{BRANCH_PROD}}` (trunk mode).
 {{/if}}
 {{/if}}
 
-If not on the required branch, abort and say: "Switch to `<required-branch>` before running `/deploy`."
+If not on the deploy branch, abort: "Switch to `<deploy-branch>` before running `/deploy`."
 
-Sync to the remote before proceeding. The script below guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<base>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from CodeCannon's own merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they get silently discarded.
+Then sync it to the remote. The script guards against uncommitted local changes, then runs `git checkout`, `git fetch`, and `git reset --hard origin/<deploy-branch>` as one atomic operation. The deploy branch is never edited locally under the CodeCannon workflow (only fast-forwarded from merges), so the hard reset is the correct sync; the dirty-tree guard catches accidental local edits before they are silently discarded.
 
-{{#if BRANCH_TEST}}
 ```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py {{BRANCH_TEST}}
+python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py <deploy-branch>
 ```
-{{/if}}
-{{#if !BRANCH_TEST}}
-{{#if BRANCH_DEV}}
-```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py {{BRANCH_DEV}}
-```
-{{/if}}
-{{#if !BRANCH_DEV}}
-```bash
-python3 CodeCannon/skills/github-agile/scripts/sync-base-branch.py {{BRANCH_PROD}}
-```
-{{/if}}
-{{/if}}
 
 If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
@@ -58,112 +43,51 @@ If the script exits non-zero, stop and resolve the issue it reports before conti
 
 ## Step 2 — Check current state
 
-### Find the latest version tag
+Find the latest version tag (`git describe --tags --abbrev=0`; if none, note this is the first release) and read the current version with `{{VERSION_READ_CMD}}`.
 
-```bash
-git describe --tags --abbrev=0
-```
-
-If no tag exists, note this is the first release.
-
-### Read current version
-
-```bash
-{{VERSION_READ_CMD}}
-```
-
-### Show commits since last tag
-
-If a previous tag exists, show what's on the branch since that tag:
+Show the merge commits (and their PRs) since the last tag. The range depends on the mode:
 
 {{#if !BRANCH_DEV}}
 ```bash
 git log <latest-tag>..HEAD --merges --pretty=format:"%s"
 ```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
 {{/if}}
 {{#if BRANCH_DEV}}
-{{#if !BRANCH_TEST}}
 ```bash
-git log {{BRANCH_PROD}}..{{BRANCH_DEV}} --merges --pretty=format:"%s"
+git log {{BRANCH_PROD}}..<deploy-branch> --merges --pretty=format:"%s"
 ```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-{{/if}}
 {{#if BRANCH_TEST}}
-```bash
-git log {{BRANCH_PROD}}..{{BRANCH_TEST}} --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects. Note: some merge commits here may be promotion merges from `{{BRANCH_DEV}}` — these are identifiable by subjects matching "Merge ... from `{{BRANCH_DEV}}`". Include them in the list but note they are promotion merges; extract the original feature PRs from their PR bodies when possible.
+Some merges here may be promotion merges from `{{BRANCH_DEV}}` (subjects matching "Merge ... from `{{BRANCH_DEV}}`"). Include them, but extract the original feature PRs from their PR bodies where possible.
 {{/if}}
 {{/if}}
 
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
+Merge-commit subjects have the form `Merge pull request #N from branch/name` — parse the PR numbers, then retrieve each body with `gh pr view <N> --json number,title,body`.
+
+From those PR bodies, compile the release's issue links:
 
 {{#if !BRANCH_DEV}}
-Extract `Closes #N` references from PR bodies. Compile:
-- List of PRs included (number + title)
-- List of issues linked to those PRs
+- **PRs included** (number + title).
+- **Issues linked** via `Closes #N`.
 {{/if}}
 {{#if BRANCH_DEV}}
-Extract closing keywords **separately** from context references — do **not** merge them into a single set:
+Keep closing keywords and context references **separate — do not merge them into one set**:
 
-- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These issues will auto-close when the release PR merges into `{{BRANCH_PROD}}`. Record, per constituent PR, the exact `Closes #N` lines it contained so they can be reproduced verbatim in the release PR body.
-- **Reference set** — issues mentioned only via `Related to #N`, or via the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the HUMAN GATE surfaces it so you can manually close any straggler that should have been a `Closes`.
-
-Compile:
-- List of PRs included (number + title)
-- Close set and reference set, kept distinct
+- **Close set** — the union of every `Closes #N` line across all constituent PR bodies. These auto-close when the release PR merges into `{{BRANCH_PROD}}`. Record, per constituent PR, the exact `Closes #N` lines so they can be reproduced verbatim in the release PR body.
+- **Reference set** — issues mentioned only via `Related to #N` or the legacy `Issue #N` form. These are context links and will **not** close. Legacy `Issue #N` carries no recoverable close-intent, so it stays in the reference set rather than being guessed into the close set; the human gate surfaces it so you can manually close any straggler that should have closed.
+- **PRs included** (number + title).
 {{/if}}
 
-### Check for open unmerged PRs
+Also check for open unmerged PRs (`gh pr list --state open --json number,title,headRefName`).
 
-```bash
-gh pr list --state open --json number,title,headRefName
-```
-
-### Present the summary
-
-Tell the user:
-
-```
-Current version: X.Y.Z
-Latest tag: vX.Y.Z
-
-Commits/PRs since last tag:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
-
-Open PRs not yet merged:
-  #19 — Add dark mode (feature/dark-mode)
-
-Would you like to bump the version before deploying?
-  - **patch** → X.Y.C
-  - **minor** → X.B.0
-  - **major** → A.0.0
-  - **specific** → enter a version number
-  - **skip** → proceed to release with the latest existing tag
-```
-
-Wait for their response.
+Present a summary — current version, latest tag, the PRs/issues since that tag, any open PRs — and ask whether to bump the version before deploying (patch → X.Y.C, minor → X.B.0, major → A.0.0, a specific version, or skip to release the latest existing tag). Wait for their response.
 
 ---
 
 ## Step 3 — Version bump (if requested)
 
-If the user chose to skip, find the latest version tag in the branch history:
-```bash
-git describe --tags --abbrev=0
-```
+If the user chose **skip**, use the latest existing tag (`git describe --tags --abbrev=0`) as the release version. If none exists (first release), warn "No version tag found. You must bump the version before deploying." and return to the bump prompt.
 
-If no tag is found at all (first release), warn: "No version tag found. You must bump the version before deploying." Return to the version bump prompt. Otherwise, use the tag found as the release version.
-
-If the user chose a bump level, map their response to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it for the release step.
+If the user chose a bump level, map it to a bump command and run `bump-and-tag.py`, which performs the bump, verifies the resulting tag (creating an annotated fallback if `tag.forceSignAnnotated` silently rejected a lightweight tag), and pushes both the commit and the tag. The resolved version is printed on stdout — capture it as `<new-version>`.
 
 | User says | `--bump-cmd` |
 |---|---|
@@ -178,111 +102,100 @@ python3 CodeCannon/skills/github-agile/scripts/bump-and-tag.py \
   --version-read-cmd "{{VERSION_READ_CMD}}"
 ```
 
-If the script exits non-zero, stop and resolve the issue it reports before continuing. On success, the version printed on stdout is the new version — use it as `<new-version>` in subsequent steps.
+If the script exits non-zero, stop and resolve the issue it reports before continuing.
 
 ---
 
 ## Step 4 — Compute release contents
 
-Determine the version tag (either from the bump just performed, or from the existing HEAD tag if the user skipped bumping).
-
-Find the previous tag to determine the range:
-```bash
-git describe --abbrev=0 <version-tag>^
-```
+Determine the release version tag (from the bump just performed, or the existing HEAD tag if the user skipped). Find the previous tag for the changelog range: `git describe --abbrev=0 <version-tag>^`.
 
 {{#if !BRANCH_DEV}}
-Find all merge commits since the previous tag:
-```bash
-git log <prev-tag>..HEAD --merges --pretty=format:"%s"
-```
-
-Parse PR numbers from merge commit subjects (format: `Merge pull request #N from branch/name`).
-
-For each PR number found, retrieve the PR body:
-```bash
-gh pr view <N> --json number,title,body
-```
-
-Extract `Closes #N` references from PR bodies (trunk PRs use `Closes #N`). Compile:
-- List of PRs included (number + title)
-- List of issues linked via `Closes #N`
+Find the merge commits since the previous tag (`git log <prev-tag>..HEAD --merges --pretty=format:"%s"`), parse their PR numbers, retrieve each body (`gh pr view <N> --json number,title,body`), and compile the PRs included plus the issues linked via `Closes #N`.
 {{/if}}
 {{#if BRANCH_DEV}}
-{{#if !BRANCH_TEST}}
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
-{{/if}}
-{{#if BRANCH_TEST}}
-Use the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch if needed.
-{{/if}}
+Reuse the PR list, close set, and reference set already computed in Step 2. If the version bump added new commits, re-fetch as needed.
 {{/if}}
 
 ---
 
 ## Step 5 — HUMAN GATE
 
-Show the user the release summary. Example format:
-
-```
-Ready to release vX.Y.Z to production.
-
-PRs included:
-  #17 — Add /docs directory
-  #18 — Fix checkout runtime error
+Show the release summary — the target version, the PRs included, and the issue links:
 
 {{#if !BRANCH_DEV}}
-Issues that will be referenced:
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
+- Issues that will be referenced.
+
+Confirm production readiness: "Have you confirmed everything above is ready for production? Type 'release' to confirm."
 {{/if}}
 {{#if BRANCH_DEV}}
-Issues that will close on merge (Closes #N, reproduced verbatim from constituent PRs):
-  #14 — Add /docs directory
-  #15 — Fix checkout runtime error
+- Issues that will **close** on merge (the close set, reproduced verbatim from constituent PRs).
+- Issues **referenced but not closing** (the reference set — confirm none of these should actually close).
 
-Issues referenced but NOT closing (Related to #N / legacy Issue #N — confirm none of these should actually close):
-  #20 — Tighten error copy on the upload form
-{{/if}}
-
-{{#if !BRANCH_DEV}}
-Have you confirmed everything above is ready for production? Type 'release' to confirm.
-{{/if}}
-{{#if BRANCH_DEV}}
-{{#if !BRANCH_TEST}}
-Have you tested all of the above on preview? Type 'release' to confirm.
-{{/if}}
+Confirm the deploy branch has been tested:
 {{#if BRANCH_TEST}}
-Have you tested all of the above on the {{BRANCH_TEST}} environment? Type 'release' to confirm.
+"Have you tested all of the above on the {{BRANCH_TEST}} environment? Type 'release' to confirm."
+{{/if}}
+{{#if !BRANCH_TEST}}
+"Have you tested all of the above on preview? Type 'release' to confirm."
 {{/if}}
 {{/if}}
-```
 
-Wait for the user to type "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
+Wait for "release" or an explicit confirmation. Any other response → stop and ask what they'd like to change.
 
 ---
 
-{{#if !BRANCH_DEV}}
-## Step 6 — Create GitHub Release
+{{#if BRANCH_DEV}}
+## Step 6 — Promote: `<deploy-branch>` → `{{BRANCH_PROD}}`
 
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorizes the promotion/merge; the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
+Create a temp directory for this invocation (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`) and note the returned path — use it for all temp files here.
+
+Use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
+
+```markdown
+Release vX.Y.Z
+
+PRs included:
+- #17 — Add /docs directory
+- #18 — Fix checkout runtime error
+
+Closes #14
+Closes #15
+
+Related to #20
+```
+
+Reproduce **every** `Closes #N` line from the close set — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear without triggering an auto-close; if the reference set is empty, omit the `Related to` lines entirely.
+
+Create the PR (do NOT use `--body`, `--body-file -`, or heredocs), with `--head` set to the deploy branch:
+
+```bash
+gh pr create --base {{BRANCH_PROD}} --head <deploy-branch> \
+  --title "Release vX.Y.Z" \
+  --body-file <tmpdir>/release_pr_body.md
+```
+
+> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close. The `Closes #N` lines auto-close the linked issues because this PR merges into `{{BRANCH_PROD}}` (the default branch).
+
+Then merge. Do NOT use `{{MERGE_CMD}}` — it refuses PRs targeting `{{BRANCH_PROD}}`. Use `gh pr merge <pr-number> --merge` directly.
+
+---
+{{/if}}
+
+{{#if BRANCH_DEV}}
+## Step 7 — Create the GitHub Release
+{{/if}}
+{{#if !BRANCH_DEV}}
+## Step 6 — Create the GitHub Release
+{{/if}}
+
+**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action; the confirmation from Step 5 authorized the promotion, but the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
 
 > Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
 
 Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
 
----
-
-The version tag and PR/issue list are already known. If no previous tag exists, omit the "Full changelog" line.
-
-First, create a temp directory for this invocation:
-
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
+The version tag and PR/issue list are already known; the previous tag comes from Step 4 (if there is no previous tag, omit the "Full changelog" line). Create a temp directory if you haven't already (`python3 CodeCannon/skills/github-agile/scripts/make-workdir.py`), then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`:
 
 ```markdown
 ## Changes
@@ -293,7 +206,7 @@ Then use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md`
 **Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
 ```
 
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
+Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`; if a PR had no linked issue, use just the PR title. Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
 
 ```bash
 gh release create <version-tag> \
@@ -301,223 +214,15 @@ gh release create <version-tag> \
   --notes-file <tmpdir>/release_notes.md
 ```
 
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, use just the PR title.
-
-After the command runs, note the release URL from the output.
+Note the release URL from the output.
 
 ---
 
+{{#if BRANCH_DEV}}
+## Step 8 — Report
+{{/if}}
+{{#if !BRANCH_DEV}}
 ## Step 7 — Report
-
-Tell the user:
-
-> "Released vX.Y.Z. Issues closed on merge. GitHub Release vX.Y.Z created at `<url>`. Run `{{DEPLOY_PROD_CMD}}` to ship to production."
 {{/if}}
-{{#if BRANCH_DEV}}
-{{#if !BRANCH_TEST}}
-## Step 6 — Create PR: `{{BRANCH_DEV}}` → `{{BRANCH_PROD}}`
 
-First, create a temp directory for this invocation:
-
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
-
-```markdown
-Release vX.Y.Z
-
-PRs included:
-- #17 — Add /docs directory
-- #18 — Fix checkout runtime error
-
-Closes #14
-Closes #15
-
-Related to #20
-```
-
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
-
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
-
-```bash
-gh pr create --base {{BRANCH_PROD}} --head {{BRANCH_DEV}} \
-  --title "Release vX.Y.Z" \
-  --body-file <tmpdir>/release_pr_body.md
-```
-
-Note the PR number from the output.
-
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `{{BRANCH_PROD}}` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
-
----
-
-## Step 7 — Merge
-
-Do NOT use `{{MERGE_CMD}}` — it refuses PRs targeting `{{BRANCH_PROD}}`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
-
-> Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
-
-Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
-
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
-
-```markdown
-## Changes
-
-- #<issue> — <PR title> (PR #<pr-number>)
-[... one line per PR included in this release ...]
-
-**Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
-```
-
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
-
-```bash
-gh release create <version-tag> \
-  --title "<version-tag>" \
-  --notes-file <tmpdir>/release_notes.md
-```
-
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
-
----
-
-## Step 9 — Report
-
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `{{DEPLOY_PROD_CMD}}` to ship to production."
-{{/if}}
-{{#if BRANCH_TEST}}
-## Step 6 — Create PR: `{{BRANCH_TEST}}` → `{{BRANCH_PROD}}`
-
-First, create a temp directory for this invocation:
-
-```bash
-python3 CodeCannon/skills/github-agile/scripts/make-workdir.py
-```
-
-Note the returned path (e.g. `/tmp/CodeCannon/a8f3b2`). Use this path for all temp files in this invocation.
-
-Then use your file-writing tool (not Bash) to create `<tmpdir>/release_pr_body.md`:
-
-```markdown
-Release vX.Y.Z
-
-PRs included:
-- #17 — Add /docs directory
-- #18 — Fix checkout runtime error
-
-Closes #14
-Closes #15
-
-Related to #20
-```
-
-Reproduce **every** `Closes #N` line from the close set computed in Step 2 — verbatim, one per line, omitting none. Add a `Related to #N` line for each issue in the reference set so the links appear on the release PR without triggering an auto-close. If the reference set is empty, omit the `Related to` lines entirely.
-
-Then create the PR (do NOT use `--body`, `--body-file -`, or heredocs):
-
-```bash
-gh pr create --base {{BRANCH_PROD}} --head {{BRANCH_TEST}} \
-  --title "Release vX.Y.Z" \
-  --body-file <tmpdir>/release_pr_body.md
-```
-
-Note the PR number from the output.
-
-The `Closes #N` lines will auto-close the linked issues because this PR merges into `{{BRANCH_PROD}}` (the default branch).
-
-> **Critical:** Use the unqualified `#N` form only. Never write `Closes owner/repo#N`, even for same-repo refs — GitHub's closing-keyword parser only populates `closingIssuesReferences` for the unqualified form, and the qualified form silently breaks auto-close.
-
----
-
-## Step 7 — Merge
-
-Do NOT use `{{MERGE_CMD}}` — it refuses PRs targeting `{{BRANCH_PROD}}`. Use `gh pr merge` directly:
-
-```bash
-gh pr merge <pr-number> --merge
-```
-
----
-
-## Step 8 — Create GitHub Release
-
-**Publish confirmation — required before writing the release notes or creating the Release.** The GitHub Release is a public-surface action. The single word from Step 5 authorized the promotion/merge (already done); the public publish gets its own explicit confirmation. Tell the user (substitute the actual tag, e.g. `v0.13.0`):
-
-> Publishing GitHub Release `<version-tag>` — the final public step. Confirm by pasting: `publish <version-tag>`
-
-Wait for the user to paste `publish <version-tag>` (or an explicit version-named variant such as `ship <version-tag>`). Any other response → stop and ask what they'd like to change. The version-named phrase is deliberate: Claude Code's auto-mode safety classifier requires authorization that names the release before `gh release create` runs, so the generic Step 5 confirmation is not relied on for the public publish. If a harness still blocks the call after this confirmation (e.g. an older client), the user can re-confirm with `publish <version-tag> release` to unblock.
-
----
-
-The version tag (from Step 3) and the PR/issue list (from Step 4) are already known. Find the previous tag to build the changelog link:
-
-```bash
-git describe --abbrev=0 <version-tag>^
-```
-
-If no previous tag exists, omit the "Full changelog" line.
-
-Use your file-writing tool (not Bash) to create `<tmpdir>/release_notes.md` (same temp directory from Step 6):
-
-```markdown
-## Changes
-
-- #<issue> — <PR title> (PR #<pr-number>)
-[... one line per PR included in this release ...]
-
-**Full changelog:** https://github.com/<owner>/<repo>/compare/<previous-tag>...<version-tag>
-```
-
-Then create the release (do NOT use `--notes`, `--notes-file -`, or heredocs):
-
-```bash
-gh release create <version-tag> \
-  --title "<version-tag>" \
-  --notes-file <tmpdir>/release_notes.md
-```
-
-Format each PR line as `- #<linked-issue> — <PR title> (PR #<N>)`. If a PR had no linked issue, omit the `#<issue>` prefix and use just the PR title.
-
-After the command runs, note the release URL from the output.
-
----
-
-## Step 9 — Report
-
-Tell the user:
-
-> "Released vX.Y.Z. Issues #N, #M closed automatically. GitHub Release vX.Y.Z created at `<url>`. Run `{{DEPLOY_PROD_CMD}}` to ship to production."
-{{/if}}
-{{/if}}
+Tell the user: "Released vX.Y.Z. Linked issues are closed. GitHub Release vX.Y.Z created at `<url>`. Run `{{DEPLOY_PROD_CMD}}` to ship to production."

--- a/skills/github-agile/start.md
+++ b/skills/github-agile/start.md
@@ -25,17 +25,15 @@ Otherwise → go to **Case A: New work**.
 
 > **Execution order:** Resolve labels and milestones **now**, before entering Case A Step 1. If milestone auto-detection requires a user prompt (2+ open milestones), that prompt happens here — not later during issue creation. By the time you reach Step 2's human gate, all metadata must already be resolved so that Step 3 can proceed without re-prompting.
 
-The argument string may contain optional inline flags after the description. Parse as follows:
+The description may be followed by optional flags — `--label`/`-l` and `--milestone`/`-m`, in any order. Separate the description from the flags yourself; the flags carry these meanings:
 
-1. **Identify flags** — scan for the first token that starts with `--label`, `-l`, `--milestone`, or `-m`. Everything before it is the **description**. Everything from the first flag onward is **flags**.
-2. **`--label <value>` / `-l <value>`** — comma-separated label string (e.g. `bug` or `enhancement,ux`). If provided, it **bypasses label auto-selection entirely** for this invocation — use the value verbatim. Labels containing spaces must be quoted (e.g. `--label "good first issue"`).
+- **`--label <value>` / `-l <value>`** — a comma-separated label string used **verbatim**, bypassing label auto-selection entirely for this invocation. Quote values containing spaces (e.g. `--label "good first issue"`).
 {{#if DEFAULT_MILESTONE}}
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). If provided, it **replaces** the default milestone `{{DEFAULT_MILESTONE}}` for this invocation. Pass the value as-is; GitHub accepts both names and numbers.
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number that **replaces** the default milestone `{{DEFAULT_MILESTONE}}` for this invocation (GitHub accepts both names and numbers).
 {{/if}}
 {{#if !DEFAULT_MILESTONE}}
-3. **`--milestone <value>` / `-m <value>`** — milestone name or number (e.g. `Sprint 4` or `12`). Pass the value as-is; GitHub accepts both names and numbers.
+- **`--milestone <value>` / `-m <value>`** — a milestone name or number (GitHub accepts both names and numbers).
 {{/if}}
-4. **Flags may appear in any order** after the description.
 
 **Label resolution (three-tier, Case A only):**
 
@@ -81,33 +79,6 @@ After parsing flags, determine the active milestone in this order:
    - **1 result** → use its title silently. Inform the user inline: `(milestone: <title>)`.
    - **2+ results** → show the numbered list, ask once: **"Multiple open milestones — which should this issue go under? (enter a number or title, or 'none')"**. Accept milestone number, title, or "none"/"skip". Wait for response before continuing.
 
-**Examples:**
-
-{{#if TICKET_LABELS}}
-{{#if DEFAULT_MILESTONE}}
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | `{{DEFAULT_MILESTONE}}` |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | `{{DEFAULT_MILESTONE}}` |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
-| `Add dark mode --milestone sprint-4` | `Add dark mode` | auto-selected from pool | `sprint-4` |
-{{/if}}
-{{#if !DEFAULT_MILESTONE}}
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | auto-selected from pool | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
-{{/if}}
-{{/if}}
-{{#if !TICKET_LABELS}}
-| `$ARGUMENTS` | Description | Labels | Milestone |
-|---|---|---|---|
-| `Add dark mode toggle to settings page` | `Add dark mode toggle to settings page` | none (no label pool) | auto-detected |
-| `Add dark mode --label enhancement` | `Add dark mode` | `enhancement` (verbatim) | auto-detected |
-| `Add dark mode --label enhancement,ux --milestone "Sprint 4"` | `Add dark mode` | `enhancement,ux` (verbatim) | `Sprint 4` |
-{{/if}}
-
 > Replace vs append: flags **replace** auto-selection entirely, they do not append. This avoids silent label duplication and milestone conflicts.
 
 ---
@@ -145,7 +116,7 @@ If on any other branch → proceed to Case A or Case B as determined by the `$AR
 
 ### Step 1 — Investigate
 
-Read the relevant code. Propose a concrete implementation approach. Be specific about which files change and how.
+Read the relevant code using your harness's native file-reading and search tools (read, grep/glob, and the like) rather than shell pipelines — hand-rolled `find … | xargs`, `grep ; awk`, or redirection shapes trigger permission prompts that cannot be permanently allowed. Then propose a concrete implementation approach, specific about which files change and how.
 
 ### Step 2 — HUMAN GATE
 
@@ -281,7 +252,19 @@ Show the user: `On branch feature/<name>`
 
 ### Step 5 — Write the code
 
-Now write the code. Do NOT commit anything.
+Write the code using your harness's native editing tools. Do NOT commit anything.
+{{#if TEST_CMD}}
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+{{TEST_CMD}}
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
+{{/if}}
+{{#if !TEST_CMD}}
+No project test command is configured, so do not invent one to run here — verification happens at the check gate inside `/submit-for-review`.
+{{/if}}
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 
@@ -392,7 +375,19 @@ git branch --show-current
 
 ### Step 5 — Write the code
 
-Continue from where work left off. Do NOT commit.
+Continue from where work left off, using your harness's native editing tools. Do NOT commit.
+{{#if TEST_CMD}}
+To exercise your work as you go, run the project's configured test command rather than hand-rolling a test invocation — a hand-built `python3 -m unittest … > /tmp/…` or similar redirection shape triggers permission prompts that a configured command avoids:
+
+```bash
+{{TEST_CMD}}
+```
+
+If it fails because the target does not exist, tell the user rather than improvising a replacement.
+{{/if}}
+{{#if !TEST_CMD}}
+No project test command is configured, so do not invent one to run here — verification happens at the check gate inside `/submit-for-review`.
+{{/if}}
 
 When done, say: **"When you've verified locally, reply `yes` to submit, or say what to change."**
 

--- a/skills/github-agile/status.md
+++ b/skills/github-agile/status.md
@@ -4,45 +4,39 @@ description: "Code Cannon: Summarize in-progress and recently completed work fro
 args: "optional: lookback days (e.g. 14), a GitHub username (@alice), --milestone <name>, or --team"
 ---
 
-## Step 1 — Parse arguments
+## What `/status` does
 
-First, check whether `$ARGUMENTS` contains `--milestone`, `--sprint`, or `--team`.
+`/status` prints a read-only, standup-ready snapshot of in-progress and recently completed work, then a single "what's next" suggestion. It never writes to GitHub or the working tree — it only reads and reports.
 
-**Milestone mode:** If `--milestone` or `--sprint` is present, extract everything after the flag as the milestone name (trim leading/trailing whitespace; preserve internal spaces). Ignore any other arguments. Enter milestone mode (Steps M1–M3 below) and skip Steps 2–6.
-
-Examples:
-- `--milestone Sprint 4` → milestone name = `Sprint 4`
-- `--sprint Sprint 4` → milestone name = `Sprint 4`
-- `--milestone Q2 Release` → milestone name = `Q2 Release`
-- `--milestone 12` → milestone name = `12`
-
-**Team mode:** If `--team` is present, enter team mode (Steps T1–T3 below) and skip Steps 2–6. `--team` is mutually exclusive with `--milestone`/`--sprint` and username arguments. If both are present, report the conflict and stop.
-
-**Personal mode** (no `--milestone` / `--sprint` / `--team` flag): determine:
-
-- **subject**: default `@me`. If the argument starts with `@` or is a plain word that is not a number, treat it as a GitHub username. Strip the leading `@` for `gh` commands that do not accept it (e.g. `gh pr list --author alice`); keep it for display.
-- **lookback**: default `7`. If the argument is a number (digits only), use it as the lookback window in days.
-
-No argument → subject = `@me`, lookback = `7`.
+Because it is read-only, the *shape* of its output does not matter: a differently-formatted-but-accurate summary is a fine result. Derive a clear, scannable layout yourself. What this skill pins down is the data to fetch, how to classify it, and the one piece of real opinion — the "what's next" ordering.
 
 ---
 
-## Step 2 — Fetch GitHub data (run all in parallel)
+## Step 1 — Determine mode
 
-Run these commands concurrently:
+Three mutually exclusive modes, selected from `$ARGUMENTS`:
 
-**Open PRs authored by subject:**
+- **Milestone mode** — `--milestone` or `--sprint` is present. Everything after the flag is the milestone name (a name or a number; trim outer whitespace, preserve internal spaces). Ignore other arguments. Run Steps M1–M2.
+- **Team mode** — `--team` is present. Run Steps T1–T2. `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username; if combined, report the conflict and stop.
+- **Personal mode** — no mode flag. **Subject** defaults to `@me`; a `@name` or a non-numeric word is a username (strip the leading `@` for `gh` flags that reject it, keep it for display). **Lookback** defaults to `7`; a bare number is the lookback in days.
+
+---
+
+## Step 2 — Fetch GitHub data (personal mode)
+
+Run these concurrently. If any `gh` command exits non-zero (including auth errors), report the message and stop — do not retry.
+
+**Open PRs authored by subject** — request enough fields to derive health (draft, CI, review decision, merge conflict) and staleness:
 ```bash
 gh pr list --author <subject> --state open \
   --json number,title,url,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
 ```
 
-**Recently merged PRs (last `<lookback>` days):**
+**Recently merged PRs**, filtered to those merged within `<lookback>` days:
 ```bash
 gh pr list --author <subject> --state merged --limit 20 \
   --json number,title,url,mergedAt,labels,baseRefName
 ```
-Filter the results to keep only entries where `mergedAt` is within the last `<lookback>` days.
 
 **Open issues assigned to subject:**
 ```bash
@@ -50,316 +44,102 @@ gh issue list --assignee <subject> --state open \
   --json number,title,url,labels,milestone,updatedAt
 ```
 
-**PRs requesting your review** (only when subject is `@me`):
+**PRs requesting your review** — only when subject is `@me`; skip for other users:
 ```bash
 gh pr list --search "review-requested:@me" --state open \
   --json number,title,url,author,updatedAt
 ```
-Skip this query when viewing another user's status.
 
-If any `gh` command exits with a non-zero status (including auth errors), report the error message and stop. Do not retry.
-
----
-
-## Step 3 — Fetch local git context
-
-Check if the current directory is inside a git repository:
-```bash
-git rev-parse --is-inside-work-tree
-```
-
-If yes, run:
+Also fetch local git context (skip and note if not in a git repo — `git rev-parse --is-inside-work-tree`):
 ```bash
 git log --oneline --since="<lookback> days ago"
 ```
 
-If not inside a git repo, skip this step and note it was skipped in the output.
+---
+
+## Step 3 — Classify and report (personal mode)
+
+Sort items into these buckets:
+
+- **In progress** — open PRs. Identify a linked issue from the PR body (`#N`, `closes #N`, `fixes #N`, `issue #N`) and cross-reference open issues.
+- **Done** — PRs merged within the lookback window.
+- **Up next** — open issues whose number is **not** referenced by any open PR body. (An issue linked from an open PR belongs under *In progress* with that PR, not here.)
+- **Needs your review** — the review-requested query (only when subject is `@me`).
+
+For each open PR, derive health from the JSON — draft state, CI status from `statusCheckRollup`, review state from `reviewDecision`, merge conflict from `mergeable`. Present each as a compact badge; omit a badge when it does not apply or is not configured.
+
+**Staleness:** flag any open PR or issue not updated within `{{STALE_DAYS}}` days (a threshold of `0` disables staleness entirely). Note the last-updated date and age. This is a real config-driven rule — honor the threshold exactly.
+
+Report the buckets as a scannable summary: a heading naming the subject and lookback, a one-line count roll-up, then a section per non-empty bucket, then the local commits (or a note that git was skipped). Show labels/milestone only when present; dates as `YYYY-MM-DD`. If every GitHub bucket is empty, say so plainly for the subject and window.
+
+**Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Step 4 — Classify items
+## Step 4 — What's next (personal mode)
 
-Using the data from Steps 2 and 3, classify each item:
+After the summary, append **one** actionable suggestion. Gather the extra local state you need (current branch, `git status --porcelain`, latest tag via `git describe --tags --abbrev=0`, unreleased commit count via `git rev-list <tag>..HEAD --count`, and the current branch's PR review/check state via `gh pr view` — treat a non-zero exit as "no PR for this branch"). Skip git lookups when not in a repo.
 
-- **In progress** — open PRs. For each, attempt to identify a linked issue number from the PR body (look for `#N`, `closes #N`, `fixes #N`, `issue #N`). If found, cross-reference with open issues.
-- **Done** — merged PRs within the lookback window.
-- **Up next** — open issues that are NOT associated with any open PR (i.e. no open PR body references their issue number).
-- **Needs your review** — PRs from the review-requested query (only when subject is `@me`).
+Evaluate these conditions **in order** and use the **first** match. This ordering is the workflow's opinion about what the operator should do next — it is load-bearing, not formatting:
 
-An open issue that IS linked from an open PR body appears under "In progress" alongside that PR, not under "Up next".
+| Priority | Condition | Suggestion |
+|----------|-----------|------------|
+| 1 | On a `feature/*` branch with uncommitted changes | You have uncommitted changes on `<branch>`. When ready, run `/submit-for-review`. |
+| 2 | On a `feature/*` branch, open PR is `APPROVED` and all checks `COMPLETED` | PR #<number> is approved and checks pass. Consider running `/deploy`. |
+| 3 | On a `feature/*` branch with an open PR in any other state | PR #<number> (<title>) is open and awaiting review. |
+| 3.5 | Subject is `@me` and PRs request your review | Append to the current suggestion (or stand alone if nothing higher matched): You also have <N> PR(s) awaiting your review. |
+| 4 | On a `feature/*` branch, no open PR, clean tree | No open PR for `<branch>`. Run `/submit-for-review` to open one. |
+| 5 | On the integration branch with unreleased commits since the last tag | <N> commit(s) on `<branch>` since `<tag>`. Run `/deploy` when ready to release. |
+| 6 | No open PRs and no open issues assigned to subject | Nothing in progress. Run `/start` to begin new work. |
+| 7 | Open issues exist in "Up next" | Next up is #<number> (<title>). Run `/start <number>` to pick it up. |
 
-### 4a — Derive health badges
-
-For each open PR, derive the following badges:
-
-**Draft status:**
-- If `isDraft` is `true` → `[draft]`
-
-**CI check status** (from `statusCheckRollup`):
-- All checks have `status: COMPLETED` and `conclusion: SUCCESS` → `✅ checks passing`
-- Any check has `conclusion: FAILURE` → `❌ checks failing`
-- Checks are still running or have other states → `⏳ checks pending`
-- No checks configured → omit badge
-
-**Review decision** (from `reviewDecision`):
-- `APPROVED` → `✅ approved`
-- `CHANGES_REQUESTED` → `🔄 changes requested`
-- `REVIEW_REQUIRED` or empty → `⏳ awaiting review`
-
-**Merge conflict** (from `mergeable`):
-- `CONFLICTING` → `⚠️ conflicts`
-- `MERGEABLE` or `UNKNOWN` → omit badge
-
-### 4b — Flag stale items
-
-For each open PR and open issue, check `updatedAt`. If the item has not been updated within `{{STALE_DAYS}}` days (default: 14; disabled when set to 0), flag it as stale. Record the last-updated date and the number of days since the last update.
-
-A stale item gets an inline `⚠️ stale (<N>d)` badge appended after any other badges.
+If none match, omit the "what's next" section. Omit it entirely in milestone mode.
 
 ---
 
-## Step 5 — Output the summary
+## Milestone mode (Steps M1–M2)
 
-Print a formatted summary. Use this structure:
-
-```
-## Status for <subject> — last <lookback> days
-
-<N> in progress · <N> done · <N> up next[ · <N> need your review]
-
-### In progress
-- #<number> <title> [<labels>] [<milestone>] [draft]
-  PR: <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>][ · <stale badge>]
-  Linked issue: #<number> (if found)
-
-### Done
-- #<number> <title> [<labels>] — merged <date>
-  PR: <url>
-
-### Needs your review
-- #<number> <title> (by @<author>)
-  PR: <url>
-
-### Up next
-- #<number> <title> [<labels>] [<milestone>][ · <stale badge>]
-  Issue: <url>
-
-### ⚠️ Stale
-- #<number> <title> — last updated <date> (<N> days ago)
-
----
-Local commits (current branch):
-<git log output, or "skipped — not in a git repo">
-```
-
-Rules:
-- **Summary counts line**: show immediately after the heading. Omit zero-count segments (e.g., if nothing is done, skip that segment). "need your review" only appears when subject is `@me` and the count is > 0.
-- **Health badges**: show on the second line of each "In progress" item, after the PR URL, separated by ` · `. Omit individual badges that don't apply (e.g., no conflict badge if mergeable).
-- **Draft badge**: show `[draft]` inline in the first line of draft PRs, before any other badges.
-- **Stale section**: a dedicated section at the bottom (before "Local commits") listing all stale items from any section, with their last-updated date and age. This gives a consolidated view. Individual items also get the inline `⚠️ stale (<N>d)` badge in their own sections.
-- **"Needs your review" section**: only shown when subject is `@me` and there are PRs requesting review. Placed between "Done" and "Up next".
-- Omit any section that has no items — do not show an empty heading.
-- Show labels only if present; show milestone only if present.
-- Dates use `YYYY-MM-DD` format.
-- If all GitHub sections are empty, print: `Nothing found for <subject> in the last <lookback> days.`
-
-Do not post, comment, write files, or take any action. Output only.
-
----
-
-## Step 6 — What's next
-
-After the status summary, append a single actionable suggestion based on local git state and the GitHub data already fetched.
-
-### 6a — Gather additional local state
-
-Run these commands (skip if not in a git repo):
-
-```bash
-git branch --show-current
-```
-
-```bash
-git status --porcelain
-```
-
-```bash
-git describe --tags --abbrev=0
-```
-
-```bash
-git rev-list <latest-tag>..HEAD --count
-```
-
-From the GitHub data fetched in Step 2, also check for the current branch's PR approval status:
-
-```bash
-gh pr view --json number,title,url,reviewDecision,statusCheckRollup \
-  --jq '{number,title,url,reviewDecision,checks: [.statusCheckRollup[]? | .status]}'
-```
-
-If `gh pr view` exits non-zero (no PR for current branch), note that there is no open PR.
-
-### 6b — Determine suggestion
-
-Evaluate the following conditions **in order**. Use the **first** match:
-
-| Priority | Condition | Output |
-|----------|-----------|--------|
-| 1 | On a `feature/*` branch with uncommitted changes (`git status --porcelain` is non-empty) | `What's next: You have uncommitted changes on \`<branch>\`. When ready, run \`/submit-for-review\`.` |
-| 2 | On a `feature/*` branch with an open PR that has `reviewDecision: APPROVED` and all status checks are `COMPLETED` | `What's next: PR #<number> is approved and checks pass. Consider running \`/deploy\`.` |
-| 3 | On a `feature/*` branch with an open PR (any other review/check state) | `What's next: PR #<number> (<title>) is open and awaiting review.` |
-| 3.5 | Subject is `@me` and there are PRs requesting your review (from Step 2 query) | Append to the current suggestion (or show standalone if no higher priority matched): `You also have <N> PR(s) awaiting your review.` |
-| 4 | On a `feature/*` branch with no open PR and clean working tree | `What's next: No open PR for \`<branch>\`. Run \`/submit-for-review\` to open one.` |
-| 5 | On the integration branch (`dev`, `develop`, or `main` when no integration branch exists) with unreleased commits (rev-list count > 0 since last tag) | `What's next: <N> commit(s) on \`<branch>\` since \`<tag>\`. Run \`/deploy\` when ready to release.` |
-| 6 | No open PRs, no open issues assigned to subject | `What's next: Nothing in progress. Run \`/start\` to begin new work.` |
-| 7 | Open issues exist in "Up next" | `What's next: Next up is #<number> (<title>). Run \`/start <number>\` to pick it up.` |
-
-If none of the above match, omit the "What's next" section entirely.
-
-### 6c — Format
-
-Print the suggestion after a horizontal rule, below the local commits section:
-
-```
----
-🧭 <suggestion text>
-```
-
-This section is omitted in milestone mode.
-
----
-
-## Milestone mode (Steps M1–M3)
-
-Only entered when `--milestone` or `--sprint` is detected in Step 1.
-
-### Step M1 — Fetch milestone issues
-
+### M1 — Fetch
 ```bash
 gh issue list --milestone "<name>" --state all --limit 200 \
   --json number,title,state,labels,assignees,url
-```
-
-If this command fails for any reason (milestone not found, auth error, etc.), report the error and stop.
-
-### Step M2 — Classify issues
-
-Fetch all open PRs to detect which issues are in progress (with health fields):
-
-```bash
 gh pr list --state open \
   --json number,title,body,baseRefName,reviewDecision,statusCheckRollup,mergeable,isDraft
 ```
+If the issue query fails (milestone not found, auth error), report and stop.
 
-Group issues into three buckets:
+### M2 — Classify and report
 
-- **Done** — `state: closed`
-- **In progress** — `state: open` AND the issue number appears in any open PR body (look for `#<number>`, `closes #<number>`, `fixes #<number>`, `related to #<number>`, `issue #<number>`)
-- **Not started** — `state: open` AND no open PR body references the issue number
+Group the milestone's issues into three buckets:
+- **Done** — `state: closed`.
+- **In progress** — open, and the issue number is referenced by some open PR body (`#N`, `closes #N`, `fixes #N`, `related to #N`, `issue #N`). This "referenced by an open PR" definition is the real rule — apply it exactly.
+- **Not started** — open, and no open PR references it.
 
-For in-progress issues, derive health badges from the linked PR using the same rules as Step 4a (check status, review decision, draft, conflict).
-
-### Step M3 — Output the summary
-
-```
-## Sprint: <name>
-
-<Y> of <total> issues closed · <Z> in progress · <W> not started
-
-### In progress (<Z>)
-- #<number> <title> [@<assignee>] [<milestone>][ [draft]]
-  <url>  ·  <check badge>  ·  <review badge>[ · <conflict badge>]
-
-### Not started (<W>)
-- #<number> <title> [@<assignee>]
-
-### Done (<Y>)
-- #<number> <title>
-```
-
-Rules:
-- Show "In progress" first, then "Not started", then "Done"
-- Show assignee only if present; omit if unassigned
-- Show URLs only for in-progress items; omit URLs for closed issues
-- Show health badges on in-progress items (same derivation as Step 4a)
-- If a section has no items, omit it entirely
-
-Do not post, comment, write files, or take any action. Output only.
+Derive health badges for in-progress issues from their linked PR (same fields as personal mode). Report as a scannable summary titled with the milestone name and a closed/in-progress/not-started roll-up. Show assignees and URLs where they add value; omit empty buckets. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
-## Team mode (Steps T1–T3)
+## Team mode (Steps T1–T2)
 
-Only entered when `--team` is detected in Step 1.
-
-### Step T1 — Fetch all open work (run both in parallel)
-
+### T1 — Fetch (run both concurrently)
 ```bash
 gh pr list --state open --limit 100 \
   --json number,title,url,author,labels,milestone,baseRefName,body,reviewDecision,statusCheckRollup,updatedAt,mergeable,isDraft
-```
-
-```bash
 gh issue list --state open --limit 200 \
   --json number,title,url,assignees,labels,milestone,updatedAt
 ```
+If either fails, report and stop.
 
-If either command fails, report the error and stop.
+### T2 — Group and report
 
-### Step T2 — Group and classify
-
-Group items by person:
-- PRs are grouped by `author.login`
-- Issues are grouped by assignee (first assignee if multiple). Issues with no assignee go into an "Unassigned" group.
-
-Within each person's group, classify items the same way as personal mode (Step 4):
-- **In progress** — open PRs (and linked issues)
-- **Up next** — open issues not linked from any open PR
-
-Derive health badges (Step 4a) and flag stale items (Step 4b) for all items.
-
-### Step T3 — Output the team summary
-
-```
-## Team status
-
-<N> open PRs · <N> open issues · <N> people
-
-### @<person> (<N> in progress, <N> up next)
-- #<number> <title> — PR <check badge> · <review badge>[ · <conflict badge>][ · <stale badge>][ [draft]]
-  <url>
-- #<number> <title> [up next][ · <stale badge>]
-
-### @<person> (<N> in progress, <N> up next)
-...
-
-### Unassigned (<N>)
-- #<number> <title>
-  <url>
-
-### ⚠️ Stale
-- #<number> <title> (@<person>) — last updated <date> (<N> days ago)
-```
-
-Rules:
-- Sort people alphabetically by username
-- Within each person, show in-progress items first, then up-next items
-- Show health badges on PR items (same format as personal mode)
-- Show `[draft]` on draft PRs
-- Tag up-next items with `[up next]` for visual distinction
-- "Unassigned" section appears at the bottom, only if there are unassigned issues
-- "Stale" section consolidates all stale items across all people
-- Omit any section or group with no items
-- No "What's next" section in team mode
-
-Do not post, comment, write files, or take any action. Output only.
+Group by person: PRs by `author.login`; issues by first assignee (unassigned issues into an "Unassigned" group). Within each person, classify as personal mode does — **in progress** (open PRs and their linked issues) and **up next** (open issues not referenced by any open PR) — and derive health badges plus staleness. Report per-person sections with in-progress items first, an "Unassigned" section if any, and a consolidated stale section. **Do not post, comment, write files, or take any action. Output only.**
 
 ---
 
 ## Hard rules
 
-- Never write to GitHub (no comments, labels, issue updates, or PR changes).
-- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately.
-- Do not retry failed commands.
-- Strip the leading `@` from the subject when passing to `gh` flags that do not accept it.
+- Never write to GitHub (no comments, labels, issue updates, or PR changes) and never touch the working tree. Output only.
+- If `gh` is unauthenticated or any fetch fails, report the error and stop immediately. Do not retry.
+- Strip the leading `@` from the subject when passing to `gh` flags that reject it.
+- `--team` is mutually exclusive with `--milestone`/`--sprint` and with a username.
+- The `{{STALE_DAYS}}` threshold is config-driven; `0` disables staleness. The "what's next" priority ordering is fixed — evaluate top to bottom, first match wins.

--- a/templates/codecannon.yaml
+++ b/templates/codecannon.yaml
@@ -55,6 +55,11 @@ config:
   DEV_CMD: make dev
   ABANDON_CMD: make abandon
   CHECK_CMD: make check
+  # Optional: command that runs the test suite during development, so /start's coding
+  # loop points at it instead of hand-rolling a test invocation. Leave empty (the default)
+  # if the project has no separate test target — /start degrades silently and verification
+  # rests on CHECK_CMD at the /submit-for-review gate.
+  # TEST_CMD: make test
   MERGE_CMD: make merge
   DEPLOY_PREVIEW_CMD: make deploy-preview
   DEPLOY_PROD_CMD: make deploy-prod

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -401,6 +401,80 @@ class TestApplyConditionals(unittest.TestCase):
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# DEPLOY SKILL — BRANCH-MODE RENDERING
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDeployModeRendering(unittest.TestCase):
+    """Regression tests for #206: deploy.md's release steps were collapsed from three
+    near-identical per-mode copies into one shared path. These lock in that each of the
+    three branching modes still renders correctly — no leftover directives, the trunk
+    path has no promotion PR/merge, and the shared release mechanics appear exactly once.
+    """
+
+    MODES = {
+        "trunk":        {"BRANCH_PROD": "main", "BRANCH_DEV": "",    "BRANCH_TEST": ""},
+        "two-branch":   {"BRANCH_PROD": "main", "BRANCH_DEV": "dev", "BRANCH_TEST": ""},
+        "three-branch": {"BRANCH_PROD": "main", "BRANCH_DEV": "dev", "BRANCH_TEST": "test"},
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        text = (REPO_ROOT / "skills" / "github-agile" / "deploy.md").read_text()
+        cls.body = text.split("---\n", 2)[2]
+
+    def _render(self, mode):
+        return sync.apply_conditionals(self.body, self.MODES[mode])
+
+    def test_no_leftover_directives_in_any_mode(self):
+        for mode in self.MODES:
+            out = self._render(mode)
+            self.assertNotIn("{{#if", out, f"{mode} left an #if directive")
+            self.assertNotIn("{{/if}}", out, f"{mode} left a /if directive")
+
+    def test_trunk_has_no_promotion_pr_or_merge(self):
+        out = self._render("trunk")
+        self.assertNotIn("gh pr create --base", out)
+        self.assertNotIn("gh pr merge", out)
+
+    def test_multibranch_has_promotion_pr_and_merge(self):
+        for mode in ("two-branch", "three-branch"):
+            out = self._render(mode)
+            self.assertIn("gh pr create --base", out, f"{mode} missing release PR")
+            self.assertIn("gh pr merge", out, f"{mode} missing merge")
+
+    def test_release_creation_is_present_in_every_mode(self):
+        # Every mode must still create the GitHub Release exactly once (as a command).
+        for mode in self.MODES:
+            out = self._render(mode)
+            self.assertIn("gh release create <version-tag>", out, f"{mode} missing release")
+
+    def test_publish_confirmation_appears_exactly_once(self):
+        # The public-publish gate must survive the de-duplication and not be triplicated.
+        for mode in self.MODES:
+            out = self._render(mode)
+            self.assertEqual(
+                out.count("Publishing GitHub Release"), 1,
+                f"{mode} should confirm the publish exactly once")
+
+    def test_critical_unqualified_ref_note_survives_in_multibranch(self):
+        # The platform-behaviour note (unqualified #N populates closingIssuesReferences)
+        # is load-bearing and belongs to the promotion path only.
+        self.assertEqual(self._render("trunk").count("Critical:"), 0)
+        for mode in ("two-branch", "three-branch"):
+            self.assertEqual(
+                self._render(mode).count("Critical:"), 1,
+                f"{mode} lost the unqualified-#N platform note")
+
+    def test_step_numbering_matches_mode(self):
+        trunk_steps = re.findall(r"^## Step (\d+) ", self._render("trunk"), re.M)
+        multi_steps = re.findall(r"^## Step (\d+) ", self._render("two-branch"), re.M)
+        # Trunk skips the promotion step, so it has one fewer numbered step.
+        self.assertEqual(trunk_steps, ["1", "2", "3", "4", "5", "6", "7"])
+        self.assertEqual(multi_steps, ["1", "2", "3", "4", "5", "6", "7", "8"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # PLACEHOLDER SUBSTITUTION
 # ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Pulls back procedural over-specification across the skills so capable agents exercise judgment, while keeping every real business rule intact. Governed by one test, now recorded in `AGENTS.md` and the README: **prune where model variance produces a different-but-fine result; keep where it produces a wrong result.**

## What changed

- **`/status`** (365 → 145 lines) — dropped the triplicated output templates, badge→emoji mappings, and argument-tokenizing tables. Kept the 7-row "what's next" priority ordering (the workflow's opinion), `STALE_DAYS` semantics, the `--team`/`--milestone` mutual-exclusion rule, the mode grouping definitions, and the read-only safety line.
- **`/deploy`** (523 → 228 lines) — collapsed the three near-identical per-mode release blocks into one shared path. Two-branch and three-branch now differ only by the deploy-branch value; trunk keeps its genuinely different no-PR/no-merge path. Publish confirmation, the release-notes template, and `gh release create` each appear once instead of three times; the unqualified-`#N` platform note once instead of twice.
- **`/start`** — replaced the "scan for the first token" tokenizing and two worked-example tables with lean flag semantics (verbatim/replace precedence, three-tier label/milestone resolution, never-re-prompt-milestone all preserved). The investigation step now names the harness's native read/search tools instead of leaving the method open, and both write-the-code steps point at `TEST_CMD` and forbid hand-rolled `python3 -m unittest … > /tmp/…` shapes — the source of the permission prompts observed post-v0.8.0.
- **`TEST_CMD`** — new optional placeholder (`config.schema.yaml`, `templates/codecannon.yaml`, this repo's `.codecannon.yaml`). Empty by default so projects without a separate test target degrade silently rather than inventing a command.
- **`AGENTS.md`** — new "Skill design philosophy" section stating the prune/keep test once, flagging the two load-bearing categories (prompt-avoidance blocks, platform-behaviour notes), and calibrating against the weakest supported model.
- **`README.md`** — new "What makes a good skill" section linking to that guidance.

## Deliberately preserved (verified, not assumed)

Every human approval gate and its exact wording, ordering guarantees, review policy, the `--body-file`/no-heredoc prompt-avoidance blocks, and platform-behaviour notes (unqualified `#N`, `--base` reading from the API, `Closes` inert off the default branch) are all still present — confirmed by a keep-item audit across the three skills.

## Verification

- `./sync.py --validate` passes (placeholder, permission, and command-shape checks); all four adapter outputs regenerated.
- Test suite: 123 passing, including a new 7-test `TestDeployModeRendering` class that renders `deploy.md` in all three branch modes and asserts no leftover directives, correct step numbering, trunk having no PR/merge, and the gates/platform-note appearing exactly once.
- `/status` exercised live end-to-end. `/start` exercised by the session that produced this PR. `/deploy`'s trunk and three-branch paths can't run in this two-branch repo; the new mode-rendering tests cover them by construction.

Closes #206
